### PR TITLE
Pass row data to formatting function

### DIFF
--- a/src/ng2-smart-table/lib/data-set/cell.ts
+++ b/src/ng2-smart-table/lib/data-set/cell.ts
@@ -14,7 +14,7 @@ export class Cell {
   getValue(): any {
     let valid = this.column.getValuePrepareFunction() instanceof Function;
     let prepare = valid ? this.column.getValuePrepareFunction() : Cell.PREPARE;
-    return prepare.call(null, this.value);
+    return prepare.call(null, this.value, this.row.getData());
   }
 
   getColumn(): Column {


### PR DESCRIPTION
Sometimes you need information about whole data object to be able to format cell value. That is also useful for virtual fields.