### PR TITLE
added checkboxes

### DIFF
--- a/src/ng2-smart-table/components/cell/cell.component.ts
+++ b/src/ng2-smart-table/components/cell/cell.component.ts
@@ -6,7 +6,10 @@ import { Cell } from '../../lib/data-set/cell';
   selector: 'ng2-smart-table-cell',
   styles: [require('./cell.scss')],
   template: `
-    <div #cellContainer *ngIf="!cell.getRow().isInEditing && cell.getColumn().type !== 'html'">{{ cell.getValue() }}</div>
+    <div #cellContainer *ngIf="!cell.getRow().isInEditing && cell.getColumn().type !== 'html'">
+    <span *ngIf="cell.getColumn().id == 'email'"><input type="checkbox" (change)="cell.isChecked = !cell.isChecked"></span>
+      {{ cell.getValue() }}
+    </div>
     <div #cellContainer *ngIf="!cell.getRow().isInEditing && cell.getColumn().type === 'html'" [innerHTML]="cell.getValue()"></div>
     <input *ngIf="cell.getRow().isInEditing" 
       [ngClass]="inputClass"
@@ -27,6 +30,7 @@ export class CellComponent {
   @Input() mode: string = 'inline';
 
   @Output() public edited: EventEmitter<any> = new EventEmitter<any>();
+  @Output() public checked: EventEmitter<any> = new EventEmitter<any>();
 
   @ViewChild('cellContainer') cellRef: ElementRef;
 
@@ -50,5 +54,10 @@ export class CellComponent {
 
   onClick(event): void {
     event.stopPropagation();
+  }
+
+  onChecked(event): boolean {
+    this.checked.emit(this.cell.getValue());
+    return false;
   }
 }

--- a/src/ng2-smart-table/lib/data-set/cell.ts
+++ b/src/ng2-smart-table/lib/data-set/cell.ts
@@ -5,10 +5,13 @@ import { Row } from './row';
 export class Cell {
 
   newValue = '';
+  isChecked = false;
+
   protected static PREPARE = (value) => value;
 
   constructor(protected value: any, protected row: Row, protected column, protected dataSet: DataSet) {
     this.newValue = value;
+    this.isChecked = false;
   }
 
   getValue(): any {

--- a/src/ng2-smart-table/ng2-smart-table.component.ts
+++ b/src/ng2-smart-table/ng2-smart-table.component.ts
@@ -8,6 +8,7 @@ import { DataSource } from './lib/data-source/data-source';
 import { Row } from './lib/data-set/row';
 
 import { deepExtend } from './lib/helpers';
+import { Deferred } from './lib/helpers';
 import { LocalDataSource } from './lib/data-source/local/local.data-source';
 
 @Component({
@@ -20,6 +21,8 @@ export class Ng2SmartTableComponent implements OnChanges {
   @Input() source: any;
   @Input() settings: Object = {};
 
+  @Input() checkedUsers: any = [];
+
   @Output() public rowSelect: EventEmitter<any> = new EventEmitter<any>();
   @Output() public userRowSelect: EventEmitter<any> = new EventEmitter<any>();
   @Output() public delete: EventEmitter<any> = new EventEmitter<any>();
@@ -29,6 +32,8 @@ export class Ng2SmartTableComponent implements OnChanges {
   @Output() public deleteConfirm: EventEmitter<any> = new EventEmitter<any>();
   @Output() public editConfirm: EventEmitter<any> = new EventEmitter<any>();
   @Output() public createConfirm: EventEmitter<any> = new EventEmitter<any>();
+
+  @Output() public checkUsers: EventEmitter<any> = new EventEmitter<any>();
   
   protected grid: Grid;
   protected defaultSettings: Object = {
@@ -98,6 +103,39 @@ export class Ng2SmartTableComponent implements OnChanges {
     } else {
       this.grid.createFormShown = true;
     }
+    return false;
+  }
+
+  getCheckedRows(event): boolean {
+    this.checkedUsers = [];
+    event.stopPropagation();
+    var deferred = new Deferred();
+
+    if(this.grid.getSetting('mode') === 'external') {
+      for(var i = 0; i < this.grid.getRows().length; i++) {
+        if(this.grid.getRows()[i].getCells()[0].isChecked) {
+          this.checkedUsers.push(this.grid.getRows()[i]);
+        }
+      }
+      console.log(this.checkedUsers);
+      this.checkUsers.emit({
+        checkedEmails: this.checkedUsers
+      });
+
+      //else code is being triggered as of now
+      } 
+      else {
+        for(var i = 0; i < this.grid.getRows().length; i++) {
+          if(this.grid.getRows()[i].getCells()[0].isChecked) {
+            this.checkedUsers.push(this.grid.getRows()[i]);
+          }
+        }
+        this.checkUsers.emit({
+          data: this.checkedUsers,
+          source: this.source,
+          confirm: deferred
+        });
+      }
     return false;
   }
 


### PR DESCRIPTION
I found this workaround since I wanted the option to select some users from the table to export to csv file.

`checkUsers` is a simple event just like the rest shown below.

`<ng2-smart-table [settings]="settings" [source]="users" (deleteConfirm)="onDeleteConfirm($event)" (editConfirm)="onSaveConfirm($event)" (createConfirm)="onCreateConfirm($event)" (checkUsers)="rowsSelected($event)" (userRowSelect)="currentRow($event)"></ng2-smart-table>`  

One of the known bugs is that the checked items are only recorded for the current page. So when you navigate to another page the checkboxes from previous page are cleared.