### PR TITLE
Column types documentation

### DIFF
--- a/demo/src/app/pages/demo/components/advanced-example-types.component.ts
+++ b/demo/src/app/pages/demo/components/advanced-example-types.component.ts
@@ -121,11 +121,14 @@ export class AdvancedExamplesTypesComponent {
         }
       },
       email: {
-        title: 'Email'
+        title: 'Email',
+        type: 'string'
       },
       comments: {
         title: 'Comments',
-        type: 'textarea'
+        editor: {
+          type: 'textarea'
+        }
       }
     }
   };

--- a/demo/src/app/pages/documentation/documentation.component.ts
+++ b/demo/src/app/pages/documentation/documentation.component.ts
@@ -5,6 +5,7 @@ import 'style-loader!./documentation.scss';
 @Component({
   selector: 'demo',
   templateUrl: 'documentation.html',
+  styleUrls: ['documentation.scss']
 })
 export class DocumentationComponent {
 

--- a/demo/src/app/pages/documentation/documentation.html
+++ b/demo/src/app/pages/documentation/documentation.html
@@ -97,8 +97,8 @@
     </tr>
     <tr>
       <td>type</td>
-      <td><span class="highlight">'string'</span>|<span class="highlight">'html'</span></td>
-      <td>'string'</td>
+      <td><span class="highlight">'text'</span>|<span class="highlight">'html'</span></td>
+      <td>'text'</td>
       <td>
         Column data type. NOTE: currently not fully supported.<br>
         If type is <span class="highlight">html</span> then cell value will be inserted as html.
@@ -114,7 +114,7 @@
     </tr>
     <tr>
       <td><span class="nested-obj">editor</span>.type</td>
-      <td><span class="highlight">'text' | 'textarea' | 'completer' | 'list' | 'checkbox'</span></td>
+      <td><span class="highlight">'text' | 'textarea' | 'completer' | 'list'</span></td>
       <td>'text'</td>
       <td>
         Editor used when new row is added or edited
@@ -134,7 +134,7 @@
       <td>[ ]</td>
       <td>
         Only on <span class="highlight">list</span> type. Example format:<br>
-        <code>{{ '{' }} value: 'ElementValue', title: 'ElementTitle' {{ '}' }}</code><br>
+        <code>{{ '{' }} value: 'Element Value', title: 'Element Title' {{ '}' }}</code><br>
         Html is supported if column type is <span class="highlight">'html'</span>
       </td>
     </tr>

--- a/demo/src/app/pages/documentation/documentation.html
+++ b/demo/src/app/pages/documentation/documentation.html
@@ -105,6 +105,83 @@
       </td>
     </tr>
     <tr>
+      <td>editor</td>
+      <td><span class="highlight">Object</span></td>
+      <td>n/a</td>
+      <td>
+        Editor attributes settings
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor</span>.type</td>
+      <td><span class="highlight">'text' | 'textarea' | 'completer' | 'list' | 'checkbox'</span></td>
+      <td>'text'</td>
+      <td>
+        Editor used when new row is added or edited
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor</span>.config</td>
+      <td><span class="highlight">Object</span></td>
+      <td>n/a</td>
+      <td>
+        Editor configuration settings. Mandatory only for editor types <span class="highlight">completer</span>, <span class="highlight">list</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor.config</span>.list</td>
+      <td><span class="highlight">Array</span></td>
+      <td>[ ]</td>
+      <td>
+        Only on <span class="highlight">list</span> type. Example format:<br>
+        <code>{{ '{' }} value: 'ElementValue', title: 'ElementTitle' {{ '}' }}</code><br>
+        Html is supported if column type is <span class="highlight">'html'</span>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor.config</span>.completer</td>
+      <td><span class="highlight">Object</span></td>
+      <td>n/a</td>
+      <td>
+        Only on <span class="highlight">completer</span> type. Example format:<br>
+        Completer configuration settings
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor.config.completer</span>.data</td>
+      <td><span class="highlight">Array</span></td>
+      <td>[ ]</td>
+      <td>
+        Autocomplete list data source.<br>
+        Example format:<br>
+        <code>{{ '{' }} id: 10, name: 'Nick', email: 'rey@karina.biz' {{ '}' }}</code>
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor.config.completer</span>.searchFields</td>
+      <td><span class="highlight">string</span></td>
+      <td>''</td>
+      <td>
+        Comma separated list of fields to search on. Fields may contain dots for nested attributes; if empty or null all data will be returned
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor.config.completer</span>.titleField</td>
+      <td><span class="highlight">string</span></td>
+      <td>''</td>
+      <td>
+       Name of the field to use as title for the list item
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">editor.config.completer</span>.descriptionField</td>
+      <td><span class="highlight">string</span></td>
+      <td>''</td>
+      <td>
+        Name of the field to use as description for the list item
+      </td>
+    </tr>
+    <tr>
       <td>valuePrepareFunction</td>
       <td><span class="highlight">Function</span></td>
       <td>

--- a/demo/src/app/pages/documentation/documentation.scss
+++ b/demo/src/app/pages/documentation/documentation.scss
@@ -1,0 +1,3 @@
+.nested-obj{
+    color: #bdbdbd;
+}


### PR DESCRIPTION
Please give me a feedback on what should I add as documentation for the new column types. I also added a css class to style the nested properties in some of the objects of the documentation table, it seems to help readability.