### PR TITLE
Move rxjs from dependencies to devDependencies to prevent some compiling issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-smart-table",
-  "version": "0.5.2-1",
+  "version": "0.5.2-2",
   "description": "Angular 2 Smart Table",
   "author": "akveo",
   "homepage": "http://akveo.github.io/ng2-smart-table/",
@@ -8,15 +8,15 @@
   "main": "./ng2-smart-table.js",
   "typings": "./ng2-smart-table.d.ts",
   "dependencies": {
-    "ng2-completer": "^1.0.0",
-    "rxjs": "~5.0.2"
+    "ng2-completer": "^1.0.0"
   },
   "save-prefix": "^",
   "peerDependencies": {
     "@angular/common": "2.4.4",
     "@angular/compiler": "2.4.4",
     "@angular/core": "2.4.4",
-    "@angular/forms": "2.4.4"
+    "@angular/forms": "2.4.4",
+    "rxjs": "~5.0.2"
   },
   "devDependencies": {
     "@angular/common": "2.4.4",


### PR DESCRIPTION
Got this error sometimes:

> ERROR in /Users/myproject/node_modules/ng2-smart-table/src/ng2-smart-table/lib/data-source/server/server.data-source.ts (70,12): Type 'Observable<Response>' is not assignable to type 'Observable<any>'.
>   Property 'source' is protected but type 'Observable<T>' is not a class derived from 'Observable<T>'.)

This update will solve the issue.