### PR TITLE
Column checkbox select filter

### DIFF
--- a/demo/src/app/pages/demo/components/advanced-example-types.component.ts
+++ b/demo/src/app/pages/demo/components/advanced-example-types.component.ts
@@ -28,7 +28,7 @@ export class AdvancedExamplesTypesComponent {
     {
       id: 3,
       name: "Clementine Bauch",
-      username: "Samantha",
+      username: "<b>Samantha</b>",
       email: "Nathan@yesenia.net",
       comments: "Mollis latine intellegebat ei usu, veri exerci intellegebat vel cu. Eu nec ferri copiosae.",
       passed: "No",
@@ -129,6 +129,9 @@ export class AdvancedExamplesTypesComponent {
               title: 'Samantha'
             }]
           }
+        },
+        filter: {
+          useEditorConfig: true
         }
       },
       email: {

--- a/demo/src/app/pages/demo/components/advanced-example-types.component.ts
+++ b/demo/src/app/pages/demo/components/advanced-example-types.component.ts
@@ -149,6 +149,9 @@ export class AdvancedExamplesTypesComponent {
             true: 'Yes',
             false: 'No'
           }
+        },
+        filter: {
+          useEditorConfig: true
         }
       }
     }

--- a/demo/src/app/pages/documentation/documentation.html
+++ b/demo/src/app/pages/documentation/documentation.html
@@ -200,6 +200,24 @@
       </td>
     </tr>
     <tr>
+      <td>filter</td>
+      <td><span class="highlight">Object</span></td>
+      <td>n/a</td>
+      <td>
+        Filter attributes settings
+      </td>
+    </tr>
+    <tr>
+      <td><span class="nested-obj">filter</span>.useEditorConfig</td>
+      <td><span class="highlight">boolean</span></td>
+      <td>false</td>
+      <td>
+        If <code>true</code>, the cell editor and the column filter will use the same input type.<br>
+        Eg. if <span class="highlight">editor.type</span> is <span class="highlight">list</span>, the same will be for the column filter.<br>
+        Note: currently available only on types <span class="highlight">list</span> and <span class="highlight">checkbox</span>
+      </td>
+    </tr>
+    <tr>
       <td>valuePrepareFunction</td>
       <td><span class="highlight">Function</span></td>
       <td>

--- a/demo/src/app/pages/home/home.html
+++ b/demo/src/app/pages/home/home.html
@@ -12,8 +12,7 @@
   <h3><a id="demo" class="anchor" href="#demo" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Demo</h3>
   
   <div>
-    <!--<basic-example-data></basic-example-data>-->
-    <advanced-example-types></advanced-example-types>
+    <basic-example-data></basic-example-data>
   </div>
   
   <h3><a id="features" class="anchor" href="#features" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Features</h3>

--- a/demo/src/app/pages/home/home.html
+++ b/demo/src/app/pages/home/home.html
@@ -12,7 +12,8 @@
   <h3><a id="demo" class="anchor" href="#demo" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Demo</h3>
   
   <div>
-    <basic-example-data></basic-example-data>
+    <!--<basic-example-data></basic-example-data>-->
+    <advanced-example-types></advanced-example-types>
   </div>
   
   <h3><a id="features" class="anchor" href="#features" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Features</h3>

--- a/src/ng2-smart-table.module.ts
+++ b/src/ng2-smart-table.module.ts
@@ -19,6 +19,7 @@ import {
 import { FilterComponent } from './ng2-smart-table/components/filter/filter.component';
 import {
   InputFilterTypeComponent,
+  SelectFilterTypeComponent,
   CheckboxFilterTypeComponent } from './ng2-smart-table/components/filter/filter-types';
 import { PagerComponent } from './ng2-smart-table/components/pager/pager.component';
 import { NG2_SMART_TABLE_THEAD_DIRECTIVES } from './ng2-smart-table/components/thead/thead.directives';
@@ -43,6 +44,7 @@ import { NG2_SMART_TABLE_TBODY_DIRECTIVES } from './ng2-smart-table/components/t
     CheckboxEditorComponent,
     FilterComponent,
     InputFilterTypeComponent,
+    SelectFilterTypeComponent,
     CheckboxFilterTypeComponent,
     PagerComponent,
     ...NG2_SMART_TABLE_THEAD_DIRECTIVES,

--- a/src/ng2-smart-table.module.ts
+++ b/src/ng2-smart-table.module.ts
@@ -17,6 +17,9 @@ import {
   TextareaEditorComponent,
   CheckboxEditorComponent } from './ng2-smart-table/components/cell/cell-editors';
 import { FilterComponent } from './ng2-smart-table/components/filter/filter.component';
+import {
+  InputFilterTypeComponent,
+  CheckboxFilterTypeComponent } from './ng2-smart-table/components/filter/filter-types';
 import { PagerComponent } from './ng2-smart-table/components/pager/pager.component';
 import { NG2_SMART_TABLE_THEAD_DIRECTIVES } from './ng2-smart-table/components/thead/thead.directives';
 import { NG2_SMART_TABLE_TBODY_DIRECTIVES } from './ng2-smart-table/components/tbody/tbody.directives';
@@ -39,6 +42,8 @@ import { NG2_SMART_TABLE_TBODY_DIRECTIVES } from './ng2-smart-table/components/t
     TextareaEditorComponent,
     CheckboxEditorComponent,
     FilterComponent,
+    InputFilterTypeComponent,
+    CheckboxFilterTypeComponent,
     PagerComponent,
     ...NG2_SMART_TABLE_THEAD_DIRECTIVES,
     ...NG2_SMART_TABLE_TBODY_DIRECTIVES,

--- a/src/ng2-smart-table/components/filter/filter-types/checkbox-filter-type.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/checkbox-filter-type.component.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+
+import { DefaultFilter } from './default-filter';
+
+@Component({
+  selector: 'checkbox-filter-type',
+    styles: [`
+      .reset-button {
+        font-weight: normal;
+        font-size: .7rem;
+      }
+  `],
+  template: `
+    <input [(ngModel)]="checkboxValue"
+           [ngClass]="inputClass"
+           type="checkbox"
+           class="form-control"
+           (change)="onChange($event)"><br>
+    <a href="#" class="reset-button" *ngIf="hasChanged" (click)="reset($event)">reset</a>
+    `
+})
+export class CheckboxFilterTypeComponent extends DefaultFilter {
+
+  checkboxValue: boolean;
+  hasChanged: boolean = false;
+
+  onChange(event: any) {
+    this.hasChanged = true;
+    const trueVal = (this.column.getConfig() && this.column.getConfig().true) || true;
+    const falseVal = (this.column.getConfig() && this.column.getConfig().false) || false;
+    this.valueChange.emit(event.target.checked ? trueVal : falseVal);
+  }
+
+  reset(event: any) {
+    event.preventDefault();
+    this.valueChange.emit('');
+    this.checkboxValue = false;
+    this.hasChanged = false;
+  }
+}

--- a/src/ng2-smart-table/components/filter/filter-types/checkbox-filter-type.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/checkbox-filter-type.component.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { DefaultFilter } from './default-filter';
+import { Grid } from '../../../lib/grid';
 
 @Component({
   selector: 'checkbox-filter-type',
@@ -16,13 +17,14 @@ import { DefaultFilter } from './default-filter';
            type="checkbox"
            class="form-control"
            (change)="onChange($event)"><br>
-    <a href="#" class="reset-button" *ngIf="hasChanged" (click)="reset($event)">reset</a>
+    <a href="#" class="reset-button" *ngIf="hasChanged" (click)="reset($event)">{{ grid.getSetting('filter.resetCheckboxContent') }}</a>
     `
 })
 export class CheckboxFilterTypeComponent extends DefaultFilter {
 
   checkboxValue: boolean;
   hasChanged: boolean = false;
+  @Input() grid: Grid;
 
   onChange(event: any) {
     this.hasChanged = true;

--- a/src/ng2-smart-table/components/filter/filter-types/default-filter.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/default-filter.ts
@@ -1,0 +1,16 @@
+import { Input, Output, EventEmitter } from '@angular/core';
+
+import { Column } from '../../../lib/data-set/column';
+
+export class DefaultFilter implements Filter {
+
+  @Input() column: Column;
+  @Input() inputClass: string;
+  @Output() valueChange = new EventEmitter<string>();
+}
+
+export interface Filter {
+  column: Column;
+  inputClass: string;
+  valueChange: EventEmitter<string>;
+}

--- a/src/ng2-smart-table/components/filter/filter-types/index.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/index.ts
@@ -1,3 +1,4 @@
 // index.ts
 export * from './input-filter-type.component';
+export * from './select-filter-type.component';
 export * from './checkbox-filter-type.component';

--- a/src/ng2-smart-table/components/filter/filter-types/index.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/index.ts
@@ -1,0 +1,3 @@
+// index.ts
+export * from './input-filter-type.component';
+export * from './checkbox-filter-type.component';

--- a/src/ng2-smart-table/components/filter/filter-types/input-filter-type.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/input-filter-type.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+
+import { DefaultFilter } from './default-filter';
+
+@Component({
+  selector: 'input-filter-type',
+  template: `
+    <input (keyup)="onChange($event)"
+           [ngClass]="inputClass"
+           class="form-control"
+           type="text" 
+           placeholder="{{ column.title }}" />
+    `
+})
+export class InputFilterTypeComponent extends DefaultFilter {
+
+  onChange(event) {
+    // ignore tab event
+    if (event.which !== 9) {
+      this.valueChange.emit(event.target.value);
+    }
+  }
+}

--- a/src/ng2-smart-table/components/filter/filter-types/select-filter-type.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/select-filter-type.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+
+import { DefaultFilter } from './default-filter';
+
+@Component({
+  selector: 'select-filter-type',
+  template: `
+    <select [ngClass]="inputClass"
+            class="form-control"
+            (change)="valueChange.emit($event.target.value)">
+        <option value="">Select...</option>
+        <option *ngFor="let option of column.getConfig()?.list" [value]="option.value">
+            {{ option.title }}
+        </option>
+    </select>
+    `
+})
+export class SelectFilterTypeComponent extends DefaultFilter {
+}

--- a/src/ng2-smart-table/components/filter/filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit, AfterViewInit } from '@
 
 import { DataSource } from '../../lib/data-source/data-source';
 import { Column } from '../../lib/data-set/column';
+import { Grid } from '../../lib/grid';
 
 @Component({
   selector: 'ng2-smart-table-filter',
@@ -9,7 +10,13 @@ import { Column } from '../../lib/data-set/column';
   template: `
     <div class="ng2-smart-filter" *ngIf="column.isFilterable">
       <div [ngSwitch]="filterType">
+        <select-filter-type *ngSwitchCase="'list'"
+                      [column]="column"
+                      [inputClass]="inputClass"
+                      (valueChange)="_filter($event)">
+        </select-filter-type>
         <checkbox-filter-type *ngSwitchCase="'checkbox'"
+                      [grid]="grid"
                       [column]="column"
                       [inputClass]="inputClass"
                       (valueChange)="_filter($event)">
@@ -26,6 +33,7 @@ import { Column } from '../../lib/data-set/column';
 export class FilterComponent implements OnInit, AfterViewInit {
 
   filterType: string = '';
+  @Input() grid: Grid;
   @Input() column: Column;
   @Input() source: DataSource;
   @Input() inputClass: string = '';

--- a/src/ng2-smart-table/components/filter/filter.scss
+++ b/src/ng2-smart-table/components/filter/filter.scss
@@ -1,5 +1,5 @@
 /deep/ .ng2-smart-filter {
-  input {
+  input, select {
     width: 100%;
     line-height: normal;
     padding: .375rem .75rem;

--- a/src/ng2-smart-table/components/filter/filter.scss
+++ b/src/ng2-smart-table/components/filter/filter.scss
@@ -1,4 +1,4 @@
-.ng2-smart-filter {
+/deep/ .ng2-smart-filter {
   input {
     width: 100%;
     line-height: normal;

--- a/src/ng2-smart-table/components/thead/rows/thead-filters-row.component.ts
+++ b/src/ng2-smart-table/components/thead/rows/thead-filters-row.component.ts
@@ -11,7 +11,8 @@ import { Grid } from '../../../lib/grid';
                           (create)="create.emit($event)">
     </th>
     <th *ngFor="let column of grid.getColumns()" class="ng2-smart-th {{ column.id }}">
-      <ng2-smart-table-filter [source]="source"
+      <ng2-smart-table-filter [grid]="grid"
+                              [source]="source"
                               [column]="column"
                               [inputClass]="grid.getSetting('filter.inputClass')"
                               (filter)="filter.emit($event)">

--- a/src/ng2-smart-table/lib/data-set/column.ts
+++ b/src/ng2-smart-table/lib/data-set/column.ts
@@ -11,6 +11,7 @@ export class Column {
   public sortDirection: string = '';
   public defaultSortDirection: string = '';
   public editor: { type: string, config: any, component: any } = { type: '', config: {}, component: null };
+  public filter: { useEditorConfig: boolean };
   compareFunction: Function;
   valuePrepareFunction: Function;
   filterFunction: Function;
@@ -45,6 +46,7 @@ export class Column {
     this.class = this.settings['class'];
     this.type = this.prepareType();
     this.editor = this.settings['editor'];
+    this.filter = this.settings['filter'];
 
     this.isFilterable = typeof this.settings['filter'] === 'undefined' ? true : !!this.settings['filter'];
     this.defaultSortDirection = ['asc', 'desc'].indexOf(this.settings['sortDirection']) !== -1 ? this.settings['sortDirection'] : '';

--- a/src/ng2-smart-table/ng2-smart-table.component.ts
+++ b/src/ng2-smart-table/ng2-smart-table.component.ts
@@ -41,6 +41,7 @@ export class Ng2SmartTableComponent implements OnChanges {
     },
     filter: {
       inputClass: '',
+      resetCheckboxContent: 'reset'
     },
     edit: {
       inputClass: '',


### PR DESCRIPTION
When adding
```
filter: {
  useEditorConfig: true
}
```
to the column configuration it will use the editor input type as column filter.
Currently works only on checkbox and select types.

Let me know if you like this approach so I will extend it to the other built-in editors.
Thanks