### PR TITLE
Update ng2-smart-table,module.ts

### DIFF
--- a/src/ng2-smart-table.module.ts
+++ b/src/ng2-smart-table.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Ng2CompleterModule } from 'ng2-completer';
@@ -46,7 +46,8 @@ import { NG2_SMART_TABLE_TBODY_DIRECTIVES } from './ng2-smart-table/components/t
   ],
   exports: [
     ...NG2_SMART_TABLE_DIRECTIVES
-  ]
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
 })
 export class Ng2SmartTableModule {
 }


### PR DESCRIPTION
It looks like it needs to add 'schemas: [ CUSTOM_ELEMENTS_SCHEMA ]' to each component where it is using custom HTML tags to avoid template parse errors from angular 2.0.0 final. This will fix "Can't bind to 'cell' since it isn't a known property of 'select-editor'" error