### PR TITLE
Update to allow for new entry not to be added to the data source

### DIFF
--- a/src/ng2-smart-table/lib/grid.ts
+++ b/src/ng2-smart-table/lib/grid.ts
@@ -100,10 +100,14 @@ export class Grid {
     const deferred = new Deferred();
     deferred.promise.then((newData) => {
       newData = newData ? newData : row.getNewData();
+      if (deferred.resolve.skipAdd) {
+        this.createFormShown = false;
+      } else {
       this.source.prepend(newData).then(() => {
         this.createFormShown = false;
         this.dataSet.createNewRow();
-      });
+      });       
+      }
     }).catch((err) => {
       // doing nothing
     });


### PR DESCRIPTION
Change:
New setting 'confirm.resolve.skipAdd'=true will skip adding the new entry to the data source. Added to allow for better integration with rxjs and ngrx.

Short summary of issue:
The function event.confirm.resolve() does two separate things at the moment:
1. disable UI controls
2. add the new entry to the table.

This pull request allows the event.confirm.resolve() to only (1) modify the UI controls, and not (2) add the new entry to the data source by setting the new parameter 'skipAdd' to true.

The problem this new feature solves is further described in Issue #273.