### PR TITLE
Update to allow for edit not to be performed on the data source

### DIFF
--- a/src/ng2-smart-table/lib/grid.ts
+++ b/src/ng2-smart-table/lib/grid.ts
@@ -128,8 +128,11 @@ export class Grid {
     const deferred = new Deferred();
     deferred.promise.then((newData) => {
       newData = newData ? newData : row.getNewData();
-      this.source.update(row.getData(), newData).then(() => {
+      if (deferred.resolve.skipEdit) {
         row.isInEditing = false;
+      } else {
+        this.source.update(row.getData(), newData).then(() => {
+          row.isInEditing = false;
       });
     }).catch((err) => {
       // doing nothing

--- a/src/ng2-smart-table/lib/grid.ts
+++ b/src/ng2-smart-table/lib/grid.ts
@@ -134,6 +134,7 @@ export class Grid {
         this.source.update(row.getData(), newData).then(() => {
           row.isInEditing = false;
       });
+      }
     }).catch((err) => {
       // doing nothing
     });

--- a/src/ng2-smart-table/lib/grid.ts
+++ b/src/ng2-smart-table/lib/grid.ts
@@ -100,10 +100,14 @@ export class Grid {
     const deferred = new Deferred();
     deferred.promise.then((newData) => {
       newData = newData ? newData : row.getNewData();
+      if (deferred.resolve.skipAdd) {
+        this.createFormShown = false;
+      } else {
       this.source.prepend(newData).then(() => {
         this.createFormShown = false;
         this.dataSet.createNewRow();
-      });
+      });       
+      }
     }).catch((err) => {
       // doing nothing
     });


### PR DESCRIPTION
Change:
New setting 'confirm.resolve.skipEdit'=true will not perform the edit on the data source. This issue is similar to PR #274. This two changes will allow a better integration with rxjs and ngrx.

Short summary of issue:
The function event.confirm.resolve() does two separate things at the moment:

1. disable UI controls
2. perform the edit to the data source
This pull request allows the event.confirm.resolve() to only (1) modify the UI controls, and not (2) perform the edit on the data source by setting the new parameter 'skipEdit' to true.

Currently an error condition might happen when the smart table is used together with Observables. The issue is further described in Issue #279 