### PR TITLE
Allow for default value to be set for new cells

### DIFF
--- a/src/ng2-smart-table/lib/data-set/row.ts
+++ b/src/ng2-smart-table/lib/data-set/row.ts
@@ -49,7 +49,8 @@ export class Row {
   }
 
   createCell(column: Column): Cell {
-    const value = typeof this.data[column.id] === 'undefined' ? '' : this.data[column.id];
+    const defValue = (column as any).settings.defaultValue ? (column as any).settings.defaultValue : '';
+    const value = typeof this.data[column.id] === 'undefined' ? defValue : this.data[column.id];
     return new Cell(value, this, column, this._dataSet);
   }
 }


### PR DESCRIPTION
Change to allow for the default value of new cells to be set when adding a new row. The default value can be set in the column settings with the new property 'defaultValue'.

This PR solves issue #310.