### PR TITLE
Fix a bug where source changes but filter doesn't get updated

### DIFF
--- a/src/ng2-smart-table/components/filter/filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, AfterViewInit, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 
 import { DataSource } from '../../lib/data-source/data-source';
 import { Column } from '../../lib/data-set/column';

--- a/src/ng2-smart-table/components/filter/filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input, Output, EventEmitter, AfterViewInit } from '@angular/core';
+import { Component, Input, Output, EventEmitter, AfterViewInit, OnChanges, SimpleChanges } from '@angular/core';
 
 import { DataSource } from '../../lib/data-source/data-source';
 import { Column } from '../../lib/data-set/column';
+import { Subscription } from 'rxjs/Subscription';
 
 @Component({
   selector: 'ng2-smart-table-filter',
@@ -35,7 +36,7 @@ import { Column } from '../../lib/data-set/column';
     </div>
   `,
 })
-export class FilterComponent implements AfterViewInit {
+export class FilterComponent implements OnChanges {
 
   @Input() column: Column;
   @Input() source: DataSource;
@@ -45,22 +46,29 @@ export class FilterComponent implements AfterViewInit {
 
   query: string = '';
 
-  ngAfterViewInit() {
-    this.source.onChanged().subscribe((elements) => {
-      const filterConf = this.source.getFilter();
-      if (filterConf && filterConf.filters && filterConf.filters.length === 0) {
-        this.query = '';
+  protected dataChangedSub: Subscription;
 
-        // add a check for existing filters an set the query if one exists for this column
-        // this covers instances where the filter is set by user code while maintaining existing functionality
-      } else if (filterConf && filterConf.filters && filterConf.filters.length > 0) {
-        filterConf.filters.forEach((k: any, v: any) => {
-          if (k.field == this.column.id) {
-            this.query = k.search;
-          }
-        });
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.source) {
+      if (!changes.source.firstChange) {
+        this.dataChangedSub.unsubscribe();
       }
-    });
+      this.dataChangedSub = this.source.onChanged().subscribe((dataChanges) => {
+        const filterConf = this.source.getFilter();
+        if (filterConf && filterConf.filters && filterConf.filters.length === 0) {
+          this.query = '';
+
+          // add a check for existing filters an set the query if one exists for this column
+          // this covers instances where the filter is set by user code while maintaining existing functionality
+        } else if (filterConf && filterConf.filters && filterConf.filters.length > 0) {
+          filterConf.filters.forEach((k: any, v: any) => {
+            if (k.field == this.column.id) {
+              this.query = k.search;
+            }
+          });
+        }
+      });
+    }
   }
 
   onFilter(query: string) {


### PR DESCRIPTION
Replaced `ngAfterViewInit` with `onChanges` since `ngAfterViewInit` is redundant because `ViewChildren` is not declared nor queried. And a bit of subscription management (`unsubscribe` from the previous source before subscribing to the new).

Similar to #330 and #329.