### PR TITLE
Make `source` input property annotated as `DataSource` in dependent components

### DIFF
--- a/src/ng2-smart-table/components/tbody/cells/edit-delete.component.ts
+++ b/src/ng2-smart-table/components/tbody/cells/edit-delete.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 import { Grid } from '../../../lib/grid';
 import { Row } from '../../../lib/data-set/row';
+import { DataSource } from '../../../lib/data-source/data-source';
 
 @Component({
   selector: 'ng2-st-tbody-edit-delete',
@@ -16,7 +17,7 @@ export class TbodyEditDeleteComponent {
 
   @Input() grid: Grid;
   @Input() row: Row;
-  @Input() source: any;
+  @Input() source: DataSource;
   @Input() deleteConfirm: EventEmitter<any>;
   @Input() editConfirm: EventEmitter<any>;
 

--- a/src/ng2-smart-table/components/tbody/tbody.component.ts
+++ b/src/ng2-smart-table/components/tbody/tbody.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 import { Grid } from '../../lib/grid';
+import { DataSource } from '../../lib/data-source/data-source';
 
 @Component({
   selector: '[ng2-st-tbody]',
@@ -10,7 +11,7 @@ import { Grid } from '../../lib/grid';
 export class Ng2SmartTableTbodyComponent {
 
   @Input() grid: Grid;
-  @Input() source: any;
+  @Input() source: DataSource;
   @Input() deleteConfirm: EventEmitter<any>;
   @Input() editConfirm: EventEmitter<any>;
 

--- a/src/ng2-smart-table/components/thead/cells/add-button.component.ts
+++ b/src/ng2-smart-table/components/thead/cells/add-button.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter, AfterViewInit, ElementRef } from '@angular/core';
 
 import { Grid } from '../../../lib/grid';
+import { DataSource } from '../../../lib/data-source/data-source';
 
 @Component({
   selector: '[ng2-st-add-button]',
@@ -12,7 +13,7 @@ import { Grid } from '../../../lib/grid';
 export class AddButtonComponent implements AfterViewInit {
 
   @Input() grid: Grid;
-  @Input() source: any;
+  @Input() source: DataSource;
   @Output() create = new EventEmitter<any>();
 
   constructor(private ref: ElementRef) {

--- a/src/ng2-smart-table/components/thead/cells/checkbox-select-all.component.ts
+++ b/src/ng2-smart-table/components/thead/cells/checkbox-select-all.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 
 import { Grid } from '../../../lib/grid';
+import { DataSource } from '../../../lib/data-source/data-source';
 
 @Component({
   selector: '[ng2-st-checkbox-select-all]',
@@ -11,6 +12,6 @@ import { Grid } from '../../../lib/grid';
 export class CheckboxSelectAllComponent {
 
   @Input() grid: Grid;
-  @Input() source: any;
+  @Input() source: DataSource;
   @Input() isAllSelected: boolean;
 }

--- a/src/ng2-smart-table/components/thead/cells/column-title.component.ts
+++ b/src/ng2-smart-table/components/thead/cells/column-title.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 import { Column } from '../../../lib/data-set/column';
+import { DataSource } from '../../../lib/data-source/data-source';
 
 @Component({
   selector: 'ng2-st-column-title',
@@ -13,7 +14,7 @@ import { Column } from '../../../lib/data-set/column';
 export class ColumnTitleComponent {
 
   @Input() column: Column;
-  @Input() source: any;
+  @Input() source: DataSource;
 
   @Output() sort = new EventEmitter<any>();
 

--- a/src/ng2-smart-table/components/thead/rows/thead-filters-row.component.ts
+++ b/src/ng2-smart-table/components/thead/rows/thead-filters-row.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 import { Grid } from '../../../lib/grid';
+import { DataSource } from '../../../lib/data-source/data-source';
 
 @Component({
   selector: '[ng2-st-thead-filters-row]',
@@ -27,7 +28,7 @@ import { Grid } from '../../../lib/grid';
 export class TheadFitlersRowComponent {
 
   @Input() grid: Grid;
-  @Input() source: any;
+  @Input() source: DataSource;
 
   @Output() create = new EventEmitter<any>();
   @Output() filter = new EventEmitter<any>();

--- a/src/ng2-smart-table/components/thead/rows/thead-titles-row.component.ts
+++ b/src/ng2-smart-table/components/thead/rows/thead-titles-row.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 import { Grid } from '../../../lib/grid';
+import { DataSource } from '../../../lib/data-source/data-source';
 
 @Component({
   selector: '[ng2-st-thead-titles-row]',
@@ -23,7 +24,7 @@ export class TheadTitlesRowComponent {
 
   @Input() grid: Grid;
   @Input() isAllSelected: boolean;
-  @Input() source: any;
+  @Input() source: DataSource;
 
   @Output() sort = new EventEmitter<any>();
   @Output() selectAllRows = new EventEmitter<any>();

--- a/src/ng2-smart-table/components/thead/thead.component.ts
+++ b/src/ng2-smart-table/components/thead/thead.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 import { Grid } from '../../lib/grid';
+import { DataSource } from '../../lib/data-source/data-source';
 
 @Component({
     selector: '[ng2-st-thead]',
@@ -9,7 +10,7 @@ import { Grid } from '../../lib/grid';
 export class Ng2SmartTableTheadComponent {
 
     @Input() grid: Grid;
-    @Input() source: any;
+    @Input() source: DataSource;
     @Input() isAllSelected: boolean;
     @Input() createConfirm: EventEmitter<any>;
 


### PR DESCRIPTION
Make `source` input property properly and consistently annotated as `DataSource` in dependent components.