### PR TITLE
Nested properties support

### DIFF
--- a/src/ng2-smart-table/lib/data-set/row.ts
+++ b/src/ng2-smart-table/lib/data-set/row.ts
@@ -13,6 +13,15 @@ export class Row {
     this.process();
   }
 
+  function getProperty(data, property) {
+    var parts = property.split(".");
+    var prop = data;
+    for (var i = 0; i < parts.length && typeof prop !== 'undefined'; i++) {
+        prop = prop[parts[i]];
+    }
+    return prop;
+  }
+
   getCell(column: Column): Cell {
     return this.cells.find(el => el.getColumn() === column);
   }
@@ -50,7 +59,8 @@ export class Row {
 
   createCell(column: Column): Cell {
     const defValue = (column as any).settings.defaultValue ? (column as any).settings.defaultValue : '';
-    const value = typeof this.data[column.id] === 'undefined' ? defValue : this.data[column.id];
+    var value = getProperty(this.data,column.id);
+    value = typeof value === 'undefined' ? defValue : value;
     return new Cell(value, this, column, this._dataSet);
   }
 }


### PR DESCRIPTION
Support for columns with nested properties. Declare these columns
as it follows: "address.street":{title:"..."}.

Signed-off-by: Dani Ughelli <vduk225@gmail.com>