### PR TITLE
Make style optionnal

### DIFF
--- a/src/app/pages/documentation/documentation.component.html
+++ b/src/app/pages/documentation/documentation.component.html
@@ -329,6 +329,14 @@
       </td>
     </tr>
     <tr>
+      <td>defaultStyle</td>
+      <td><span class="highlight">'boolean'</span></td>
+      <td>true</td>
+      <td>
+        Set to false to not use the default style of ng2-smart-table
+      </td>
+    </tr>
+    <tr>
       <td>attr</td>
       <td><span class="highlight">Object</span></td>
       <td>n/a</td>

--- a/src/ng2-smart-table/ng2-smart-table.component.html
+++ b/src/ng2-smart-table/ng2-smart-table.component.html
@@ -1,4 +1,4 @@
-<table [id]="tableId" [ngClass]="tableClass">
+<table [id]="tableId" [ngClass]="[tableClass, defaultStyle ? 'ng2-smart-default-style' : '']">
 
   <thead ng2-st-thead *ngIf="!isHideHeader || !isHideSubHeader"
                       [grid]="grid"

--- a/src/ng2-smart-table/ng2-smart-table.component.scss
+++ b/src/ng2-smart-table/ng2-smart-table.component.scss
@@ -2,53 +2,55 @@
   font-size: 1rem;
 
   /deep/ {
-    * {
-      box-sizing: border-box;
-    }
+    .ng2-smart-default-style {
+      * {
+        box-sizing: border-box;
+      }
 
-    button,
-    input,
-    optgroup,
-    select,
-    textarea {
-      color: inherit;
-      font: inherit;
-      margin: 0;
-    }
+      button,
+      input,
+      optgroup,
+      select,
+      textarea {
+        color: inherit;
+        font: inherit;
+        margin: 0;
+      }
 
-    table {
-      line-height: 1.5em;
-      border-collapse: collapse;
-      border-spacing: 0;
-      display: table;
-      width: 100%;
-      max-width: 100%;
-      overflow: auto;
-      word-break: normal;
-      word-break: keep-all;
+      table {
+        line-height: 1.5em;
+        border-collapse: collapse;
+        border-spacing: 0;
+        display: table;
+        width: 100%;
+        max-width: 100%;
+        overflow: auto;
+        word-break: normal;
+        word-break: keep-all;
 
-      tr {
-        th {
-          font-weight: bold;
-        }
-        section {
-          font-size: .75em;
-          font-weight: bold;
-        }
-        td,
-        th {
-          font-size: .875em;
-          margin: 0;
-          padding: 0.5em 1em;
+        tr {
+          th {
+            font-weight: bold;
+          }
+          section {
+            font-size: .75em;
+            font-weight: bold;
+          }
+          td,
+          th {
+            font-size: .875em;
+            margin: 0;
+            padding: 0.5em 1em;
+          }
         }
       }
-    }
 
-    a {
-      color: #1e6bb8;
-      text-decoration: none;
-      &:hover {
-        text-decoration: underline;
+      a {
+        color: #1e6bb8;
+        text-decoration: none;
+        &:hover {
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/src/ng2-smart-table/ng2-smart-table.component.ts
+++ b/src/ng2-smart-table/ng2-smart-table.component.ts
@@ -33,6 +33,7 @@ export class Ng2SmartTableComponent implements OnChanges {
   isHideSubHeader: boolean;
   isPagerDisplay: boolean;
   rowClassFunction: Function;
+  defaultStyle: boolean;
 
 
   grid: Grid;
@@ -41,6 +42,7 @@ export class Ng2SmartTableComponent implements OnChanges {
     selectMode: 'single', // single|multi
     hideHeader: false,
     hideSubHeader: false,
+    defaultStyle: true,
     actions: {
       columnTitle: 'Actions',
       add: true,
@@ -103,6 +105,7 @@ export class Ng2SmartTableComponent implements OnChanges {
     this.isHideSubHeader = this.grid.getSetting('hideSubHeader');
     this.isPagerDisplay = this.grid.getSetting('pager.display');
     this.rowClassFunction = this.grid.getSetting('rowClassFunction');
+    this.defaultStyle = this.grid.getSetting('defaultStyle');
   }
 
   editRowSelect(row: Row) {


### PR DESCRIPTION
This is a pull request to make the ng2-smart-table style optionnal. 

For instance if I use bootstrap css, the style is not applied because ng2-smart-table component has its own internal style.

I added a boolean parameter defaultStyle which allow to activate or disable default style.