### PR TITLE
feat(table): add support for field validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/cli": "1.0.4",
     "@angular/compiler-cli": "4.1.3",
     "@types/chalk": "0.4.31",
-    "@types/gulp": "4.0.2",
+    "@types/gulp": "4.0.3",
     "@types/highlight.js": "9.1.9",
     "@types/jasmine": "2.5.38",
     "@types/lodash": "4.14.58",

--- a/src/ng2-smart-table/components/cell/cell-editors/checkbox-editor.component.ts
+++ b/src/ng2-smart-table/components/cell/cell-editors/checkbox-editor.component.ts
@@ -9,6 +9,7 @@ import { DefaultEditor } from './default-editor';
     <input [ngClass]="inputClass"
            type="checkbox"
            class="form-control"
+           [formControl]="cell.getValidator()"
            [name]="cell.getId()"
            [disabled]="!cell.isEditable()"
            [checked]="cell.getValue() == (cell.getColumn().getConfig()?.true || true)"

--- a/src/ng2-smart-table/components/cell/cell-editors/completer-editor.component.ts
+++ b/src/ng2-smart-table/components/cell/cell-editors/completer-editor.component.ts
@@ -7,6 +7,7 @@ import { DefaultEditor } from './default-editor';
   selector: 'completer-editor',
   template: `
     <ng2-completer [(ngModel)]="completerStr"
+                   [formControl]="cell.getValidator()"
                    [dataService]="cell.getColumn().getConfig().completer.dataService"
                    [minSearchLength]="cell.getColumn().getConfig().completer.minSearchLength || 0"
                    [pause]="cell.getColumn().getConfig().completer.pause || 0"

--- a/src/ng2-smart-table/components/cell/cell-editors/input-editor.component.ts
+++ b/src/ng2-smart-table/components/cell/cell-editors/input-editor.component.ts
@@ -8,6 +8,7 @@ import { DefaultEditor } from './default-editor';
   template: `
     <input [ngClass]="inputClass"
            class="form-control"
+           [formControl]="cell.getValidator()"
            [(ngModel)]="cell.newValue"
            [name]="cell.getId()"
            [placeholder]="cell.getTitle()"

--- a/src/ng2-smart-table/components/cell/cell-editors/select-editor.component.ts
+++ b/src/ng2-smart-table/components/cell/cell-editors/select-editor.component.ts
@@ -7,6 +7,7 @@ import { DefaultEditor } from './default-editor';
   template: `
     <select [ngClass]="inputClass"
             class="form-control"
+            [formControl]="cell.getValidator()"
             [(ngModel)]="cell.newValue"
             [name]="cell.getId()"
             [disabled]="!cell.isEditable()"

--- a/src/ng2-smart-table/components/cell/cell-editors/textarea-editor.component.ts
+++ b/src/ng2-smart-table/components/cell/cell-editors/textarea-editor.component.ts
@@ -8,6 +8,7 @@ import { DefaultEditor } from './default-editor';
   template: `
     <textarea [ngClass]="inputClass"
               class="form-control"
+              [formControl]="cell.getValidator()"
               [(ngModel)]="cell.newValue"
               [name]="cell.getId()"
               [disabled]="!cell.isEditable()"

--- a/src/ng2-smart-table/components/cell/cell.module.ts
+++ b/src/ng2-smart-table/components/cell/cell.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { Ng2CompleterModule } from 'ng2-completer';
 
 import { CellComponent } from './cell.component';
@@ -33,6 +33,7 @@ const CELL_COMPONENTS = [
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     Ng2CompleterModule,
   ],
   declarations: [

--- a/src/ng2-smart-table/components/tbody/cells/create-cancel.component.ts
+++ b/src/ng2-smart-table/components/tbody/cells/create-cancel.component.ts
@@ -33,6 +33,7 @@ export class TbodyCreateCancelComponent implements OnChanges {
     event.stopPropagation();
 
     this.row.isInEditing = false;
+    this.grid.dataSet.getRowValidator(this.row.index).reset();
   }
 
   ngOnChanges() {

--- a/src/ng2-smart-table/components/thead/cells/actions.component.ts
+++ b/src/ng2-smart-table/components/thead/cells/actions.component.ts
@@ -10,7 +10,7 @@ import { Grid } from '../../../lib/grid';
         (click)="$event.preventDefault();create.emit($event)"></a>
     <a href="#" class="ng2-smart-action ng2-smart-action-add-cancel"
         [innerHTML]="cancelButtonContent"
-        (click)="$event.preventDefault();grid.createFormShown = false;"></a>
+        (click)="$event.preventDefault();grid.createFormShown = false; grid.dataSet.newRowValidator.reset();"></a>
   `,
 })
 export class ActionsComponent implements OnChanges {

--- a/src/ng2-smart-table/index.ts
+++ b/src/ng2-smart-table/index.ts
@@ -1,4 +1,5 @@
 export * from './ng2-smart-table.module';
+export { ValidatorService } from './lib/validator.service';
 export { ViewCell } from './components/cell/cell-view-mode/view-cell';
 export { DefaultEditor, Editor } from './components/cell/cell-editors/default-editor';
 export { Cell } from './lib/data-set/cell';

--- a/src/ng2-smart-table/lib/data-set/cell.ts
+++ b/src/ng2-smart-table/lib/data-set/cell.ts
@@ -1,3 +1,5 @@
+import { AbstractControl } from '@angular/forms';
+
 import { Column } from './column';
 import { DataSet } from './data-set';
 import { Row } from './row';
@@ -13,6 +15,10 @@ export class Cell {
 
   getColumn(): Column {
     return this.column;
+  }
+
+  getValidator(): AbstractControl {
+    return this.dataSet.getRowValidator(this.getRow().index).controls[this.getId()];
   }
 
   getRow(): Row {

--- a/src/ng2-smart-table/lib/data-set/data-set.ts
+++ b/src/ng2-smart-table/lib/data-set/data-set.ts
@@ -1,21 +1,43 @@
+import { FormGroup, FormControl } from '@angular/forms';
+
 import { Row } from './row';
 import { Column } from './column';
+import { ValidatorService } from '../validator.service';
 
 export class DataSet {
 
   newRow: Row;
 
+  public newRowValidator: FormGroup;
+  public editRowValidators: FormGroup[];
   protected data: Array<any> = [];
   protected columns: Array<Column> = [];
   protected rows: Array<Row> = [];
   protected selectedRow: Row;
   protected willSelect: string = 'first';
 
-  constructor(data: Array<any> = [], protected columnSettings: Object) {
+  constructor(data: Array<any> = [], protected columnSettings: Object, private validator: ValidatorService) {
+    this.createValidators(columnSettings);
     this.createColumns(columnSettings);
     this.setData(data);
 
     this.createNewRow();
+  }
+
+  addDefaultsToFormGroup(formGroup: FormGroup): FormGroup {
+    if(this.columnSettings)
+      for (const id in this.columnSettings)
+          if (!formGroup.controls[id] && this.columnSettings.hasOwnProperty(id))
+              formGroup.controls[id] = new FormControl();
+    return formGroup;
+  }
+
+  createValidators(columnSettings: Object){
+    this.newRowValidator = this.addDefaultsToFormGroup(this.validator.getFormGroup());
+    this.editRowValidators = new Array<FormGroup>();
+    this.data.forEach(() => {
+      this.editRowValidators.push(this.addDefaultsToFormGroup(this.validator.getFormGroup()));
+    });
   }
 
   setData(data: Array<any>) {
@@ -37,6 +59,13 @@ export class DataSet {
 
   getLastRow(): Row {
     return this.rows[this.rows.length - 1];
+  }
+
+  getRowValidator(index:number): FormGroup {
+    if(index === -1)
+      return this.newRowValidator;
+    else
+      return this.editRowValidators[index] as FormGroup;
   }
 
   findRowByData(data: any): Row {
@@ -116,6 +145,11 @@ export class DataSet {
     }
 
     return this.selectedRow;
+  }
+
+  addInsertedRowValidator(): void {
+    this.newRowValidator.reset();
+    this.editRowValidators = [this.addDefaultsToFormGroup(this.validator.getFormGroup())].concat(this.editRowValidators);
   }
 
   createNewRow() {

--- a/src/ng2-smart-table/lib/default-validator.service.ts
+++ b/src/ng2-smart-table/lib/default-validator.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { ValidatorService } from './validator.service';
+
+@Injectable()
+export class DefaultValidatorService implements ValidatorService {
+    getFormGroup(): FormGroup {
+        return new FormGroup({});
+
+    }
+}

--- a/src/ng2-smart-table/lib/grid.ts
+++ b/src/ng2-smart-table/lib/grid.ts
@@ -7,6 +7,7 @@ import { Column } from './data-set/column';
 import { Row } from './data-set/row';
 import { DataSet } from './data-set/data-set';
 import { DataSource } from './data-source/data-source';
+import { ValidatorService } from './validator.service';
 
 export class Grid {
 
@@ -18,8 +19,8 @@ export class Grid {
 
   onSelectRowSource = new Subject<any>();
 
-  constructor(source: DataSource, settings: any) {
-    this.setSettings(settings);
+  constructor(source: DataSource, settings: any, validator: ValidatorService) {
+    this.setSettings(settings, validator);
     this.setSource(source);
   }
 
@@ -43,9 +44,9 @@ export class Grid {
     return this.dataSet.newRow;
   }
 
-  setSettings(settings: Object) {
+  setSettings(settings: Object, validator: ValidatorService) {
     this.settings = settings;
-    this.dataSet = new DataSet([], this.getSetting('columns'));
+    this.dataSet = new DataSet([], this.getSetting('columns'), validator);
 
     if (this.source) {
       this.source.refresh();
@@ -96,7 +97,7 @@ export class Grid {
   }
 
   create(row: Row, confirmEmitter: EventEmitter<any>) {
-
+    
     const deferred = new Deferred();
     deferred.promise.then((newData) => {
       newData = newData ? newData : row.getNewData();
@@ -105,6 +106,7 @@ export class Grid {
       } else {
         this.source.prepend(newData).then(() => {
           this.createFormShown = false;
+          this.dataSet.addInsertedRowValidator();
           this.dataSet.createNewRow();
         });
       }
@@ -117,38 +119,47 @@ export class Grid {
         newData: row.getNewData(),
         source: this.source,
         confirm: deferred,
+        validator: this.dataSet.newRowValidator,
       });
     } else {
-      deferred.resolve();
+      if(this.dataSet.newRowValidator.invalid)
+        deferred.reject();
+      else
+        deferred.resolve();
     }
   }
 
   save(row: Row, confirmEmitter: EventEmitter<any>) {
 
-    const deferred = new Deferred();
-    deferred.promise.then((newData) => {
-      newData = newData ? newData : row.getNewData();
-      if (deferred.resolve.skipEdit) {
-        row.isInEditing = false;
-      } else {
-        this.source.update(row.getData(), newData).then(() => {
+      const deferred = new Deferred();
+      deferred.promise.then((newData) => {
+        newData = newData ? newData : row.getNewData();
+        if (deferred.resolve.skipEdit) {
           row.isInEditing = false;
-        });
-      }
-    }).catch((err) => {
-      // doing nothing
-    });
-
-    if (this.getSetting('edit.confirmSave')) {
-      confirmEmitter.emit({
-        data: row.getData(),
-        newData: row.getNewData(),
-        source: this.source,
-        confirm: deferred,
+        } else {
+          this.source.update(row.getData(), newData).then(() => {
+            row.isInEditing = false;
+            this.dataSet.newRowValidator.reset();
+          });
+        }
+      }).catch((err) => {
+        // doing nothing
       });
-    } else {
-      deferred.resolve();
-    }
+
+      if (this.getSetting('edit.confirmSave')) {
+        confirmEmitter.emit({
+          data: row.getData(),
+          newData: row.getNewData(),
+          source: this.source,
+          confirm: deferred,
+          validator: this.dataSet.getRowValidator(row.index),
+        });
+      } else {
+        if(this.dataSet.getRowValidator(row.index).invalid)
+          deferred.reject();
+        else
+          deferred.resolve();
+      }
   }
 
   delete(row: Row, confirmEmitter: EventEmitter<any>) {
@@ -156,6 +167,7 @@ export class Grid {
     const deferred = new Deferred();
     deferred.promise.then(() => {
       this.source.remove(row.getData());
+      this.dataSet.editRowValidators = this.dataSet.editRowValidators.splice(row.index, 1);
     }).catch((err) => {
       // doing nothing
     });

--- a/src/ng2-smart-table/lib/validator.service.ts
+++ b/src/ng2-smart-table/lib/validator.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Injectable()
+export abstract class ValidatorService {
+    abstract getFormGroup(): FormGroup;
+}

--- a/src/ng2-smart-table/ng2-smart-table.component.ts
+++ b/src/ng2-smart-table/ng2-smart-table.component.ts
@@ -5,6 +5,7 @@ import { DataSource } from './lib/data-source/data-source';
 import { Row } from './lib/data-set/row';
 import { deepExtend } from './lib/helpers';
 import { LocalDataSource } from './lib/data-source/local/local.data-source';
+import { ValidatorService } from './lib/validator.service';
 
 @Component({
   selector: 'ng2-smart-table',
@@ -34,6 +35,7 @@ export class Ng2SmartTableComponent implements OnChanges {
   isPagerDisplay: boolean;
   rowClassFunction: Function;
 
+  constructor(private validator: ValidatorService) { }
 
   grid: Grid;
   defaultSettings: Object = {
@@ -88,7 +90,7 @@ export class Ng2SmartTableComponent implements OnChanges {
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     if (this.grid) {
       if (changes['settings']) {
-        this.grid.setSettings(this.prepareSettings());
+        this.grid.setSettings(this.prepareSettings(), this.validator);
       }
       if (changes['source']) {
         this.source = this.prepareSource();
@@ -150,8 +152,8 @@ export class Ng2SmartTableComponent implements OnChanges {
 
   initGrid() {
     this.source = this.prepareSource();
-    this.grid = new Grid(this.source, this.prepareSettings());
-    this.grid.onSelectRow().subscribe((row) => this.emitSelectRow(row));
+    this.grid = new Grid(this.source, this.prepareSettings(), this.validator);
+    this.grid.onSelectRow().subscribe((row) => this.emitSelectRow(row));  
   }
 
   prepareSource(): DataSource {

--- a/src/ng2-smart-table/ng2-smart-table.module.ts
+++ b/src/ng2-smart-table/ng2-smart-table.module.ts
@@ -9,6 +9,8 @@ import { TBodyModule } from './components/tbody/tbody.module';
 import { THeadModule } from './components/thead/thead.module';
 
 import { Ng2SmartTableComponent } from './ng2-smart-table.component';
+import { ValidatorService } from './lib/validator.service';
+import { DefaultValidatorService } from './lib/default-validator.service';
 
 @NgModule({
   imports: [
@@ -26,6 +28,9 @@ import { Ng2SmartTableComponent } from './ng2-smart-table.component';
   ],
   exports: [
     Ng2SmartTableComponent,
+  ],
+  providers: [
+    { provide: ValidatorService, useClass: DefaultValidatorService }
   ],
 })
 export class Ng2SmartTableModule {


### PR DESCRIPTION
Adds support for field validation using Angular validation structures for that purpose: `FormGroup` and `FormControl`, providing validation with `confirmSave`/`confirmCreate` and without it.

To specify the validation for the fields, a custom instance of ValidatorService must be implemented and provided in the component that instanciate the table.

Events emitted by `confirmEmitter` in case of `confirmSave` and `confirmCreate` contain the `FormGroup` (or the extension defined in `ValidatorService`'s implementation) that validates the row. There can be checked the fields with errors, display custom messages inline, etc.

To extend the validation, it can be done in multiple ways:
-Providing `DefaultEditor` extensions that show messages depending on `FormControl.error` values.
-Validating table input with extensions of FormGroup and FormControl classes, and invoke custom actions with them in case that error happens (this can be implemented only with `confirmSave`/`confirmCreate`).

Example with `FormGroup` and `FormControl` extensions, with `confirmSave` and `confirmCreate` both in `true`:
![smart-table-validation](https://user-images.githubusercontent.com/22963558/28626640-f030de96-71f5-11e7-8efe-cfffe30d9abb.png)

