### PR TITLE
Add example of using config in CustomEditorComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@angular/cli": "1.0.4",
     "@angular/compiler-cli": "4.1.3",
     "@types/chalk": "0.4.31",
-    "@types/gulp": "4.0.2",
+    "@types/gulp": "^4.0.3",
     "@types/highlight.js": "9.1.9",
     "@types/jasmine": "2.5.38",
     "@types/lodash": "4.14.58",

--- a/src/app/pages/examples/custom-edit-view/advanced-example-custom-editor.component.ts
+++ b/src/app/pages/examples/custom-edit-view/advanced-example-custom-editor.component.ts
@@ -57,6 +57,9 @@ export class AdvancedExamplesCustomEditorComponent {
         editor: {
           type: 'custom',
           component: CustomEditorComponent,
+          config: {
+            openInNewWindow: true,
+          },
         },
       },
     },

--- a/src/app/pages/examples/custom-edit-view/custom-editor.component.ts
+++ b/src/app/pages/examples/custom-edit-view/custom-editor.component.ts
@@ -33,6 +33,8 @@ export class CustomEditorComponent extends DefaultEditor implements AfterViewIni
   @ViewChild('url') url: ElementRef;
   @ViewChild('htmlValue') htmlValue: ElementRef;
 
+  openInNewWindow: boolean;
+
   constructor() {
     super();
   }
@@ -42,12 +44,26 @@ export class CustomEditorComponent extends DefaultEditor implements AfterViewIni
       this.name.nativeElement.value = this.getUrlName();
       this.url.nativeElement.value = this.getUrlHref();
     }
+
+    this.openInNewWindow = this.cell.getColumn().getConfig()
+      ? this.cell.getColumn().getConfig().openInNewWindow || false
+      : false;
   }
 
   updateValue() {
     const href = this.url.nativeElement.value;
     const name = this.name.nativeElement.value;
-    this.cell.newValue = `<a href='${href}'>${name}</a>`;
+
+    let value;
+
+    if (this.openInNewWindow) {
+      value = `<a href='${href}' target="_blank">${name}</a>`;
+    } else {
+      value = `<a href='${href}'>${name}</a>`;
+    }
+
+    this.cell.newValue = value;
+
   }
 
   getUrlName(): string {


### PR DESCRIPTION
Fix #384 updating `@types/gulp` version.

Add an example of using `config` with **CustomEditorComponent**. There is no documentation about accessing config from a cell: `this.cell.getColumn().getConfig()`.