### PR TITLE
Manually set page

### DIFF
--- a/src/ng2-smart-table/components/pager/pager.component.ts
+++ b/src/ng2-smart-table/components/pager/pager.component.ts
@@ -42,8 +42,20 @@ export class PagerComponent implements OnChanges {
 
   @Output() changePage = new EventEmitter<any>();
 
+  @Input()
+  set page(pn: number) {
+    if (pn) {
+      this.paginate(pn);
+    }
+  }
+
+  get page(): number {
+    return this._page;
+  }
+
+
   protected pages: Array<any>;
-  protected page: number;
+  protected _page: number;
   protected count: number = 0;
   protected perPage: number;
 
@@ -55,11 +67,11 @@ export class PagerComponent implements OnChanges {
         this.dataChangedSub.unsubscribe();
       }
       this.dataChangedSub = this.source.onChanged().subscribe((dataChanges) => {
-        this.page = this.source.getPaging().page;
+        this._page = this.source.getPaging().page;
         this.perPage = this.source.getPaging().perPage;
         this.count = this.source.count();
         if (this.isPageOutOfBounce()) {
-          this.source.setPage(--this.page);
+          this.source.setPage(--this._page);
         }
 
         this.processPageChange(dataChanges);
@@ -89,7 +101,7 @@ export class PagerComponent implements OnChanges {
 
   paginate(page: number): boolean {
     this.source.setPage(page);
-    this.page = page;
+    this._page = page;
     this.changePage.emit({ page });
     return false;
   }

--- a/src/ng2-smart-table/ng2-smart-table.component.html
+++ b/src/ng2-smart-table/ng2-smart-table.component.html
@@ -29,5 +29,6 @@
 
 <ng2-smart-table-pager *ngIf="isPagerDisplay"
                         [source]="source"
+                        [(page)]="page"
                         (changePage)="changePage($event)">
 </ng2-smart-table-pager>

--- a/src/ng2-smart-table/ng2-smart-table.component.ts
+++ b/src/ng2-smart-table/ng2-smart-table.component.ts
@@ -15,6 +15,7 @@ export class Ng2SmartTableComponent implements OnChanges {
 
   @Input() source: any;
   @Input() settings: Object = {};
+  @Input() page: number;
 
   @Output() rowSelect = new EventEmitter<any>();
   @Output() userRowSelect = new EventEmitter<any>();


### PR DESCRIPTION
Currently the setPage method from data source does not update the bottom pager.

This commit allows update the pager from the directive

 <ng2-smart-table [page]="page" [settings]="settings" [source]="source" (deleteConfirm)="onDeleteConfirm($event)"></ng2-smart-table>

export class table{
public page:number;
constructor(){
this.source.load([{name:'a'},{name:'b'}])
this.page = 2;
}

which is useful for appending page number from routing.
