### PR TITLE
Add action custom flag to correct colspan for no data row

### DIFF
--- a/src/ng2-smart-table/components/tbody/tbody.component.html
+++ b/src/ng2-smart-table/components/tbody/tbody.component.html
@@ -50,7 +50,7 @@
 </tr>
 
 <tr *ngIf="grid.getRows().length == 0">
-  <td [attr.colspan]="grid.getColumns().length + (isActionAdd || isActionEdit || isActionDelete)">
+  <td [attr.colspan]="grid.getColumns().length + (isActionAdd || isActionEdit || isActionDelete || isActionCustom)">
     {{ noDataMessage }}
   </td>
 </tr>

--- a/src/ng2-smart-table/components/tbody/tbody.component.ts
+++ b/src/ng2-smart-table/components/tbody/tbody.component.ts
@@ -37,6 +37,7 @@ export class Ng2SmartTableTbodyComponent {
   isActionAdd: boolean;
   isActionEdit: boolean;
   isActionDelete: boolean;
+  isActionCustom: boolean;
   noDataMessage: boolean;
 
   ngOnChanges() {
@@ -48,6 +49,7 @@ export class Ng2SmartTableTbodyComponent {
     this.isActionAdd = this.grid.getSetting('actions.add');
     this.isActionEdit = this.grid.getSetting('actions.edit');
     this.isActionDelete = this.grid.getSetting('actions.delete');
+    this.isActionCustom = !!this.grid.getSetting('actions.custom');
     this.noDataMessage = this.grid.getSetting('noDataMessage');
   }
 }


### PR DESCRIPTION
When action custom is specified and no data for table, the no data row does not calculate colspan attribute properly because it does not account for custom action.