### PR TITLE
added ngOnInit() to main component

### DIFF
--- a/src/ng2-smart-table/ng2-smart-table.component.ts
+++ b/src/ng2-smart-table/ng2-smart-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, SimpleChange, EventEmitter, OnChanges } from '@angular/core';
+import { Component, Input, Output, SimpleChange, EventEmitter, OnChangesm, OnInit } from '@angular/core';
 
 import { Grid } from './lib/grid';
 import { DataSource } from './lib/data-source/data-source';
@@ -84,7 +84,11 @@ export class Ng2SmartTableComponent implements OnChanges {
   };
 
   isAllSelected: boolean = false;
-
+  
+  ngOnInit() {
+    this.ngOnChanges({});
+  }
+  
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     if (this.grid) {
       if (changes['settings']) {


### PR DESCRIPTION
If you create Ng2SmartTableComponent dynamically with resolveComponentFactory() and createComponent() then sub-components like Head and Body will fail with errors, because Ng2SmartTableComponent.grid will not be initialized, because ngOnChanges() not invoked