### PR TITLE
added support of ServerDataSource

### DIFF
--- a/src/ng2-smart-table/components/cell/cell.component.ts
+++ b/src/ng2-smart-table/components/cell/cell.component.ts
@@ -7,10 +7,10 @@ import { Row } from '../../lib/data-set/row';
 @Component({
   selector: 'ng2-smart-table-cell',
   template: `
-    <table-cell-view-mode *ngIf="!isInEditing" [cell]="cell"></table-cell-view-mode>
+    <table-cell-view-mode *ngIf="!isInEditing" [cell]="cell" (dblclick)="dblclick()"></table-cell-view-mode>
     <table-cell-edit-mode *ngIf="isInEditing" [cell]="cell"
                           [inputClass]="inputClass"
-                          (edited)="onEdited($event)">
+                          (edited)="onEdited($event)" (dblclick)="dblclick()">
     </table-cell-edit-mode>
   `,
 })
@@ -27,6 +27,7 @@ export class CellComponent {
   @Input() isInEditing: boolean = false;
 
   @Output() edited = new EventEmitter<any>();
+  @Output() doubleClick = new EventEmitter<any>();
 
   onEdited(event: any) {
     if (this.isNew) {
@@ -34,5 +35,9 @@ export class CellComponent {
     } else {
       this.grid.save(this.row, this.editConfirm);
     }
+  }
+  
+  dblclick() {
+      this.doubleClick.emit({row: this.row, cell: this.cell, grid: this.grid, cellComponent: this});
   }
 }

--- a/src/ng2-smart-table/lib/data-source/server/server.data-source.ts
+++ b/src/ng2-smart-table/lib/data-source/server/server.data-source.ts
@@ -33,7 +33,6 @@ export class ServerDataSource extends LocalDataSource {
     return this.requestElements().map(res => {
       this.lastRequestCount = this.extractTotalFromResponse(res);
       this.data = this.extractDataFromResponse(res);
-
       return this.data;
     }).toPromise();
   }

--- a/src/ng2-smart-table/lib/helpers.ts
+++ b/src/ng2-smart-table/lib/helpers.ts
@@ -96,3 +96,39 @@ export function getDeepFromObject(object = {}, name: string, defaultValue?: any)
 
   return typeof level === 'undefined' ? defaultValue : level;
 }
+
+declare let Reflect: any;
+export function getAnnotations(typeOrFunc: any): any[]|null {
+  // Prefer the direct API.
+  if ((<any>typeOrFunc).annotations) {
+    let annotations = (<any>typeOrFunc).annotations;
+    if (typeof annotations === 'function' && annotations.annotations) {
+      annotations = annotations.annotations;
+    }
+    return annotations;
+  }
+
+  // API of tsickle for lowering decorators to properties on the class.
+  if ((<any>typeOrFunc).decorators) {
+    return convertTsickleDecoratorIntoMetadata((<any>typeOrFunc).decorators);
+  }
+
+  // API for metadata created by invoking the decorators.
+  if (Reflect && Reflect.getOwnMetadata) {
+    return Reflect.getOwnMetadata('annotations', typeOrFunc);
+  }
+  return null;
+}
+
+export function convertTsickleDecoratorIntoMetadata(decoratorInvocations: any[]): any[] {
+  if (!decoratorInvocations) {
+    return [];
+  }
+  return decoratorInvocations.map(decoratorInvocation => {
+    const decoratorType = decoratorInvocation.type;
+    const annotationCls = decoratorType.annotationCls;
+    const annotationArgs = decoratorInvocation.args ? decoratorInvocation.args : [];
+    return new annotationCls(...annotationArgs);
+  });
+}
+

--- a/src/ng2-smart-table/ng2-smart-table.module.ts
+++ b/src/ng2-smart-table/ng2-smart-table.module.ts
@@ -8,7 +8,12 @@ import { PagerModule } from './components/pager/pager.module';
 import { TBodyModule } from './components/tbody/tbody.module';
 import { THeadModule } from './components/thead/thead.module';
 
+import {ServerDataSource} from './lib/data-source/server/server.data-source';
+import {ServerSourceConf} from './lib/data-source/server/server-source.conf';
+
 import { Ng2SmartTableComponent } from './ng2-smart-table.component';
+
+import {HttpClientModule} from '@angular/common/http';
 
 @NgModule({
   imports: [
@@ -20,13 +25,16 @@ import { Ng2SmartTableComponent } from './ng2-smart-table.component';
     PagerModule,
     TBodyModule,
     THeadModule,
+    HttpClientModule
   ],
   declarations: [
-    Ng2SmartTableComponent,
+    Ng2SmartTableComponent
   ],
   exports: [
-    Ng2SmartTableComponent,
+    Ng2SmartTableComponent
   ],
+  providers: [
+  ]
 })
 export class Ng2SmartTableModule {
 }


### PR DESCRIPTION
If to Ng2SmartTableComponent.source provide a string, it will be treated as URL to data, component will automatically create instance of ServerDataSource (ReflectiveInjector was used as ServerDataSource relays on deprecated Http angular class, should be HttpClient in new branches)

also previous commint included (ngOnInit() https://github.com/akveo/ng2-smart-table/pull/672 )