### PR TITLE
Only update filter onChanged() if setFilter was the action

### DIFF
--- a/src/ng2-smart-table/components/filter/filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter.component.ts
@@ -60,7 +60,7 @@ export class FilterComponent implements OnChanges {
 
           // add a check for existing filters an set the query if one exists for this column
           // this covers instances where the filter is set by user code while maintaining existing functionality
-        } else if (filterConf && filterConf.filters && filterConf.filters.length > 0) {
+        } else if (filterConf && filterConf.filters && filterConf.filters.length > 0 && dataChanges.action === 'setFilter') {
           filterConf.filters.forEach((k: any, v: any) => {
             if (k.field == this.column.id) {
               this.query = k.search;

--- a/src/ng2-smart-table/lib/data-source/data-source.ts
+++ b/src/ng2-smart-table/lib/data-source/data-source.ts
@@ -83,13 +83,13 @@ export abstract class DataSource {
 
   setFilter(conf: Array<any>, andOperator?: boolean, doEmit?: boolean) {
     if (doEmit) {
-      this.emitOnChanged('filter');
+      this.emitOnChanged('setFilter');
     }
   }
 
   addFilter(fieldConf: {}, andOperator?: boolean, doEmit?: boolean) {
     if (doEmit) {
-      this.emitOnChanged('filter');
+      this.emitOnChanged('addFilter');
     }
   }
 

--- a/src/ng2-smart-table/lib/grid.ts
+++ b/src/ng2-smart-table/lib/grid.ts
@@ -185,7 +185,7 @@ export class Grid {
   }
 
   shouldProcessChange(changes: any): boolean {
-    if (['filter', 'sort', 'page', 'remove', 'refresh', 'load', 'paging'].indexOf(changes['action']) !== -1) {
+    if (['setFilter', 'addFilter', 'sort', 'page', 'remove', 'refresh', 'load', 'paging'].indexOf(changes['action']) !== -1) {
       return true;
     } else if (['prepend', 'append'].indexOf(changes['action']) !== -1 && !this.getSetting('pager.display')) {
       return true;


### PR DESCRIPTION
This fix is to accomodate slow servers, where a user could be mid-typing, and if the server then responds, their input gets cleared and reset to the filter the server last saw. This is partially due to the input debounce time. Since the app doesn't know the user wants to update the filter until they are done typing.

Fixes #681