### PR TITLE
fix(add-button): IE11 classList polyfill support

### DIFF
--- a/src/ng2-smart-table/components/thead/cells/add-button.component.ts
+++ b/src/ng2-smart-table/components/thead/cells/add-button.component.ts
@@ -23,7 +23,8 @@ export class AddButtonComponent implements AfterViewInit, OnChanges {
   }
 
   ngAfterViewInit() {
-    this.ref.nativeElement.classList.add('ng2-smart-actions-title', 'ng2-smart-actions-title-add');
+    this.ref.nativeElement.classList.add('ng2-smart-actions-title');
+    this.ref.nativeElement.classList.add('ng2-smart-actions-title-add');
   }
 
   ngOnChanges() {


### PR DESCRIPTION
The polyfill that gets pulled in to support classList in angular, doesn't support splat. Just a single element.