### PR TITLE
Fix filter not set

### DIFF
--- a/src/ng2-smart-table/components/filter/filter-types/checkbox-filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/checkbox-filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 
 import { DefaultFilter } from './default-filter';
@@ -19,6 +19,15 @@ export class CheckboxFilterComponent extends DefaultFilter implements OnInit {
 
   constructor() {
     super();
+  }
+
+  @Input() set queryText(query: string) {
+    if (this.query !== query) {
+      this.inputControl.setValue(query, { emitEvent: false });
+    }
+    if (query === '') {
+      this.filterActive = false;
+    }
   }
 
   ngOnInit() {

--- a/src/ng2-smart-table/components/filter/filter-types/default-filter.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/default-filter.ts
@@ -5,12 +5,16 @@ import { Column } from '../../../lib/data-set/column';
 
 export class DefaultFilter implements Filter, OnDestroy {
 
+  query: string = '';
   delay: number = 300;
   changesSubscription: Subscription;
-  @Input() query: string;
   @Input() inputClass: string;
   @Input() column: Column;
   @Output() filter = new EventEmitter<string>();
+
+  @Input() set queryText(query: string) {
+    this.query = query;
+  }
 
   ngOnDestroy() {
     if (this.changesSubscription) {
@@ -27,7 +31,7 @@ export interface Filter {
 
   delay?: number;
   changesSubscription?: Subscription;
-  query: string;
+  queryText: string;
   inputClass: string;
   column: Column;
   filter: EventEmitter<string>;

--- a/src/ng2-smart-table/components/filter/filter-types/input-filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/input-filter.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { debounceTime, distinctUntilChanged, skip } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 import { DefaultFilter } from './default-filter';
 
@@ -19,17 +19,18 @@ export class InputFilterComponent extends DefaultFilter implements OnInit {
 
   inputControl = new FormControl();
 
+  @Input() set queryText(query: string) {
+    this.query = query;
+    this.inputControl.setValue(query);
+  }
+
   constructor() {
     super();
   }
 
   ngOnInit() {
-    if (this.query) {
-      this.inputControl.setValue(this.query);
-    }
     this.inputControl.valueChanges
       .pipe(
-        skip(1),
         distinctUntilChanged(),
         debounceTime(this.delay),
       )

--- a/src/ng2-smart-table/components/filter/filter-types/select-filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/select-filter.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { distinctUntilChanged, debounceTime, skip } from 'rxjs/operators';
+import { distinctUntilChanged, debounceTime } from 'rxjs/operators';
 
 import { DefaultFilter } from './default-filter';
 
@@ -9,7 +9,6 @@ import { DefaultFilter } from './default-filter';
   template: `
     <select [ngClass]="inputClass"
             class="form-control"
-            [(ngModel)]="query"
             [formControl]="inputControl">
 
         <option value="">{{ column.getFilterConfig().selectText }}</option>
@@ -23,6 +22,11 @@ export class SelectFilterComponent extends DefaultFilter implements OnInit {
 
   inputControl = new FormControl();
 
+  @Input() set queryText(query: string) {
+    this.query = query;
+    this.inputControl.setValue(query);
+  }
+
   constructor() {
     super();
   }
@@ -30,10 +34,12 @@ export class SelectFilterComponent extends DefaultFilter implements OnInit {
   ngOnInit() {
     this.inputControl.valueChanges
       .pipe(
-        skip(1),
         distinctUntilChanged(),
         debounceTime(this.delay)
       )
-      .subscribe((value: string) => this.setFilter());
+      .subscribe((value: string) => {
+        this.query = this.inputControl.value;
+        this.setFilter();
+      });
   }
 }

--- a/src/ng2-smart-table/components/filter/filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter.component.ts
@@ -10,25 +10,25 @@ import { Subscription } from 'rxjs';
   template: `
     <div class="ng2-smart-filter" *ngIf="column.isFilterable" [ngSwitch]="column.getFilterType()">
       <select-filter *ngSwitchCase="'list'"
-                     [query]="query"
+                     [queryText]="query"
                      [ngClass]="inputClass"
                      [column]="column"
                      (filter)="onFilter($event)">
       </select-filter>
       <checkbox-filter *ngSwitchCase="'checkbox'"
-                       [query]="query"
+                       [queryText]="query"
                        [ngClass]="inputClass"
                        [column]="column"
                        (filter)="onFilter($event)">
       </checkbox-filter>
       <completer-filter *ngSwitchCase="'completer'"
-                        [query]="query"
+                        [queryText]="query"
                         [ngClass]="inputClass"
                         [column]="column"
                         (filter)="onFilter($event)">
       </completer-filter>
       <input-filter *ngSwitchDefault
-                    [query]="query"
+                    [queryText]="query"
                     [ngClass]="inputClass"
                     [column]="column"
                     (filter)="onFilter($event)">


### PR DESCRIPTION
For those people who have implemented a "Clear filters" button in one way or another, the commit done on June 12 (e00c77f116917aa0c054de8be8eeef05a5392a9d) removed any chance to set filter input value from code except during component initialization.

Here is the example of how it is NOT working now:
https://stackblitz.com/edit/ng2-smart-table-clear-filters-angular-6
while it was working like a charm before.