### PR TITLE
Fix: Filter gets applied only after second character

### DIFF
--- a/src/ng2-smart-table/components/filter/filter-types/input-filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/input-filter.component.ts
@@ -29,7 +29,6 @@ export class InputFilterComponent extends DefaultFilter implements OnInit {
     }
     this.inputControl.valueChanges
       .pipe(
-        skip(1),
         distinctUntilChanged(),
         debounceTime(this.delay),
       )


### PR DESCRIPTION
Fixes #842

Removed skip(1) from input-filter so single-character filter queries are applied.