### PR TITLE
fix: rm skip(1) in input-filter

### DIFF
--- a/src/ng2-smart-table/components/filter/filter-types/input-filter.component.ts
+++ b/src/ng2-smart-table/components/filter/filter-types/input-filter.component.ts
@@ -29,7 +29,6 @@ export class InputFilterComponent extends DefaultFilter implements OnInit {
     }
     this.inputControl.valueChanges
       .pipe(
-        skip(1),
         distinctUntilChanged(),
         debounceTime(this.delay),
       )


### PR DESCRIPTION
skip(1) in input-filter cause the following issues:

1) Cannot support searching for items length equal to 1 (such as id, etc)
2) Cannot support languages like Chinese, Japanese, etc, which need an IME for input, FormControl can only get 'valueChanges' event one time for the whole sentance output by IME