### PR TITLE
Made changes to default sorting and filtering to support nested objects.

### DIFF
--- a/src/ng2-smart-table/lib/data-source/local/local.filter.ts
+++ b/src/ng2-smart-table/lib/data-source/local/local.filter.ts
@@ -8,8 +8,12 @@ export class LocalFilter {
     const filter: Function = customFilter ? customFilter : this.FILTER;
 
     return data.filter((el) => {
-      const value = typeof el[field] === 'undefined' || el[field] === null ? '' : el[field];
-      return filter.call(null, value, search);
+      let parts = field.split(".");
+      let prop = el;
+      for (var i = 0; i < parts.length && typeof prop !== 'undefined'; i++) {
+        prop = prop[parts[i]];
+      }
+      return filter.call(null, prop, search);
     });
   }
 }

--- a/src/ng2-smart-table/lib/data-source/local/local.sorter.ts
+++ b/src/ng2-smart-table/lib/data-source/local/local.sorter.ts
@@ -16,7 +16,16 @@ export class LocalSorter {
     const compare: Function = customCompare ? customCompare : this.COMPARE;
 
     return data.sort((a, b) => {
-      return compare.call(null, dir, a[field], b[field]);
+      let parts = field.split(".");
+      let propA = a;
+      for (var i = 0; i < parts.length && typeof propA !== 'undefined'; i++) {
+        propA = propA[parts[i]];
+      }
+      let propB = b;
+      for (var i = 0; i < parts.length && typeof propB !== 'undefined'; i++) {
+        propB = propB[parts[i]];
+      }
+      return compare.call(null, dir, propA, propB);
     });
   }
 }


### PR DESCRIPTION
I've raised **#930 (issue)**. Kindly have a look at same. 
Sending a PR request as well. It fixes the issue of **sorting and filtering** for nested properties/objects as source #360  for ng-smart-table.