### PR TITLE
Added logic to show/hide column based on settings

### DIFF
--- a/src/ng2-smart-table/lib/data-set/data-set.ts
+++ b/src/ng2-smart-table/lib/data-set/data-set.ts
@@ -131,7 +131,10 @@ export class DataSet {
   createColumns(settings: any) {
     for (const id in settings) {
       if (settings.hasOwnProperty(id)) {
-        this.columns.push(new Column(id, settings[id], this));
+        const setting = settings[id];
+        if(!setting.hide){
+          this.columns.push(new Column(id, settings[id], this));
+        }
       }
     }
   }


### PR DESCRIPTION
Added logic to show/hide column based on settings. User can provide a hide flag inside column, when creating settings. If hide flag will be set to true, column will not be shown on the UI.

To toggle the column, user will have to manipulate the value of hide variable for the column of interest.

Example:
 ```
columns: {
        projectName: {
        title: 'Project',
        hide: false
      },      
      status: {
        title: 'Status',
        hide: false
      }
}
```

To hide:
`settings.columns.status.hide = true;`