### PR TITLE
responsive fix: 

### DIFF
--- a/src/ng2-smart-table/components/cell/cell-view-mode/view-cell.component.ts
+++ b/src/ng2-smart-table/components/cell/cell-view-mode/view-cell.component.ts
@@ -7,9 +7,9 @@ import { Cell } from '../../../lib/data-set/cell';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div [ngSwitch]="cell.getColumn().type">
-        <custom-view-component *ngSwitchCase="'custom'" [cell]="cell"></custom-view-component>
-        <div *ngSwitchCase="'html'" [innerHTML]="cell.getValue()"></div>
-        <div *ngSwitchDefault>{{ cell.getValue() }}</div>
+        <custom-view-component *ngSwitchCase="'custom'" data-title="{{cell.getTitle()}}"  [cell]="cell"></custom-view-component>
+        <div *ngSwitchCase="'html'" data-title="{{cell.getTitle()}}" [innerHTML]="cell.getValue()"></div>
+        <div data-title="{{cell.getTitle()}}" *ngSwitchDefault>{{ cell.getValue() }}</div>
     </div>
     `,
 })

--- a/src/ng2-smart-table/components/cell/cell-view-mode/view-cell.component.ts
+++ b/src/ng2-smart-table/components/cell/cell-view-mode/view-cell.component.ts
@@ -8,8 +8,8 @@ import { Cell } from '../../../lib/data-set/cell';
   template: `
     <div [ngSwitch]="cell.getColumn().type">
         <custom-view-component *ngSwitchCase="'custom'" data-title="{{cell.getTitle()}}"  [cell]="cell"></custom-view-component>
-        <div *ngSwitchCase="'html'" data-title="{{cell.getTitle()}}" [innerHTML]="cell.getValue()"></div>
-        <div data-title="{{cell.getTitle()}}" *ngSwitchDefault>{{ cell.getValue() }}</div>
+        <div class="ng2-smart-table-cell-value" *ngSwitchCase="'html'" data-title="{{cell.getTitle()}}" [innerHTML]="cell.getValue()"></div>
+        <div class="ng2-smart-table-cell-value" data-title="{{cell.getTitle()}}" *ngSwitchDefault>{{ cell.getValue() }}</div>
     </div>
     `,
 })


### PR DESCRIPTION
added id so that it can be used as a stackable table with addition of css below:

the operative part is:
###     **.ng2-smart-table-cell-value:before {
        content: attr(title);**




// repsonsive stackable tables scss
@media only screen and (max-width: 800px) {

    .ng2-smart-table-cell-value:before {
        content: attr(title);
        position: absolute;
        top: 6px;
        left: 6px;
        width: 45%;
        padding-right: 10px;
        white-space: nowrap;
        text-align: left;
        font-weight: bold;
    }  
  
    ng2-smart-table td .ng2-smart-table-cell-value {
        border-bottom: 1px solid #eee;
        position: relative;
        padding-left: 50% !important;
        white-space: normal;
        text-align: left; 
        display: block;
    } 
    
    ng2-smart-table ng2-smart-table-cell td  {
        border: none;
        border-bottom: 1px solid #eee;
        position: relative;
        padding-left: 50% !important;
        white-space: normal;
        text-align: left; 
        display: block;
    }

    //give it a stackable class such not to break existing 
    ng2-smart-table thead{
        display: none;
    }
        
    //give it a stackable class such not to break existing 
    ng2-smart-table table, ng2-smart-table  tbody, ng2-smart-table  th, ng2-smart-table  td, ng2-smart-table  tr {
        display: block;
    }
    
}

