### PR TITLE
DOCUMENTATION CORRECTION: trypho corrected on events name

### DIFF
--- a/src/app/pages/documentation/documentation.component.html
+++ b/src/app/pages/documentation/documentation.component.html
@@ -461,7 +461,7 @@
       <td><span class="highlight">boolean</span></td>
       <td>false</td>
       <td>
-        Enable/disable <span class="highlight">(confirmEdit)</span> event. If enabled data will be edited only if confirm.resolve() called.
+        Enable/disable <span class="highlight">(editConfirm)</span> event. If enabled data will be edited only if confirm.resolve() called.
       </td>
     </tr>
     <tr>
@@ -509,7 +509,7 @@
       <td><span class="highlight">boolean</span></td>
       <td>false</td>
       <td>
-        Enable/disable <span class="highlight">(confirmCreate)</span> event. If enabled data will be added only if confirm.resolve() called.
+        Enable/disable <span class="highlight">(createConfirm)</span> event. If enabled data will be added only if confirm.resolve() called.
       </td>
     </tr>
     <tr>
@@ -533,7 +533,7 @@
       <td><span class="highlight">boolean</span></td>
       <td>false</td>
       <td>
-        Enable/disable <span class="highlight">(confirmDelete)</span> event. If enabled data will be deleted only if confirm.resolve() called.
+        Enable/disable <span class="highlight">(deleteConfirm)</span> event. If enabled data will be deleted only if confirm.resolve() called.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
The documentation refered at one point at events (editConfirm), (createConfirm) and  (deleteConfirm) as (confirmEdit), (confirmCreate) and (confirmDelete), causing me some headaches.

This pull request corrects the documentation to make the correct references. 