### PR TITLE
Added ng2-completer to the install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ At the moment we cannot give our full attention to the library, and only plannin
 The library is available as npm package, so all you need to do is to run the following command:
 
 ```
-npm install --save ng2-smart-table
+npm install --save ng2-smart-table ng2-completer
 ```
 
 This command will create a record in your `package.json` file and install the package into the npm modules folder.


### PR DESCRIPTION
I found myself with the same issue reported in issue [#917](https://github.com/akveo/ng2-smart-table/issues/917) where the tutorial failed for lack of the ng2-completer dependency. So I added it to the npm install command.