### PR TITLE
Only import needed parts of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "pree2e": "webdriver-manager update --standalone false --gecko false",
     "e2e": "ng e2e",
     "clean:dist": "npm run rimraf -- dist",
-    "changelog": "standard-changelog"
+    "changelog": "standard-changelog",
+    "build:stats": "ng build --prod --aot --stats-json",
+    "analyze": "webpack-bundle-analyzer dist/stats.json"
   },
   "dependencies": {
     "@angular/animations": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "core-js": "2.5.6",
     "gulp-rename": "^1.3.0",
     "highlight.js": "9.12.0",
-    "lodash": "4.17.10",
+    "lodash.clonedeep": "4.5.0",
     "ng2-completer": "1.6.3",
     "normalize.css": "8.0.0",
     "rxjs": "6.1.0",

--- a/src/ng2-smart-table/lib/helpers.ts
+++ b/src/ng2-smart-table/lib/helpers.ts
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash';
+import * as cloneDeep from 'lodash.clonedeep';
 
 /**
  * Extending object that entered in first argument.


### PR DESCRIPTION
The idea is to reduce the bundle size. It appears to me that cloneDeep is the only part of lodash that is used.

I've attached two screenshots. One of a webpack bundle analysis before the change and one after. The effect will be more significant in the packaged version, since highlights are not included there.