### PR TITLE
Resolves willSelect bug on row selection (issue #502)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4242,7 +4242,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4263,12 +4264,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4283,17 +4286,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4410,7 +4416,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4422,6 +4429,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4436,6 +4444,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4443,12 +4452,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4467,6 +4478,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4547,7 +4559,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4559,6 +4572,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4644,7 +4658,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4680,6 +4695,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4699,6 +4715,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4742,12 +4759,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/projects/demo/src/app/pages/examples/examples.module.ts
+++ b/projects/demo/src/app/pages/examples/examples.module.ts
@@ -24,6 +24,7 @@ import { ServerExamplesComponent } from './server/server-examples.component';
 import { CustomViewEditExamplesComponent } from './custom-edit-view/custom-edit-view-examples.component';
 import { BasicExampleCustomActionsComponent } from './custom-edit-view/basic-example-custom-actions.component';
 import { VariousExamplesComponent } from './various/various-examples.component';
+import { BasicExampleRowSelectionComponent } from './various/basic-example-row-selection.component';
 
 import {
   BasicExampleButtonViewComponent,
@@ -49,6 +50,7 @@ const EXAMPLES_COMPONENTS = [
   BasicExampleButtonViewComponent,
   BasicExampleCustomActionsComponent,
   ButtonViewComponent,
+  BasicExampleRowSelectionComponent
 ];
 
 @NgModule({

--- a/projects/demo/src/app/pages/examples/various/basic-example-row-selection.component.ts
+++ b/projects/demo/src/app/pages/examples/various/basic-example-row-selection.component.ts
@@ -1,0 +1,106 @@
+import { Component } from '@angular/core';
+import { DataSet } from 'dist/ng2-smart-table/lib/lib/data-set/data-set';
+
+@Component({
+  selector: 'basic-example-row-selection',
+  template: `
+    <ng2-smart-table [settings]="settings" [source]="data" (afterGridInit)="onGridInit($event)"></ng2-smart-table>
+  `,
+})
+export class BasicExampleRowSelectionComponent {
+
+  settings = {
+    selectMode: 'multi',
+    columns: {
+      id: {
+        title: 'ID',
+      },
+      name: {
+        title: 'Full Name',
+      },
+      username: {
+        title: 'User Name',
+      },
+      email: {
+        title: 'Email',
+      },
+    },
+  };
+
+  data = [
+    {
+      id: 1,
+      name: 'Leanne Graham',
+      username: 'Bret',
+      email: 'Sincere@april.biz',
+    },
+    {
+      id: 2,
+      name: 'Ervin Howell',
+      username: 'Antonette',
+      email: 'Shanna@melissa.tv',
+    },
+    {
+      id: 3,
+      name: 'Clementine Bauch',
+      username: 'Samantha',
+      email: 'Nathan@yesenia.net',
+    },
+    {
+      id: 4,
+      name: 'Patricia Lebsack',
+      username: 'Karianne',
+      email: 'Julianne.OConner@kory.org',
+    },
+    {
+      id: 5,
+      name: 'Chelsey Dietrich',
+      username: 'Kamren',
+      email: 'Lucio_Hettinger@annie.ca',
+    },
+    {
+      id: 6,
+      name: 'Mrs. Dennis Schulist',
+      username: 'Leopoldo_Corkery',
+      email: 'Karley_Dach@jasper.info',
+    },
+    {
+      id: 7,
+      name: 'Kurtis Weissnat',
+      username: 'Elwyn.Skiles',
+      email: 'Telly.Hoeger@billy.biz',
+    },
+    {
+      id: 8,
+      name: 'Nicholas Runolfsdottir V',
+      username: 'Maxime_Nienow',
+      email: 'Sherwood@rosamond.me',
+    },
+    {
+      id: 9,
+      name: 'Glenna Reichert',
+      username: 'Delphine',
+      email: 'Chaim_McDermott@dana.io',
+    },
+    {
+      id: 10,
+      name: 'Clementina DuBuque',
+      username: 'Moriah.Stanton',
+      email: 'Rey.Padberg@karina.biz',
+    },
+    {
+      id: 11,
+      name: 'Nicholas DuBuque',
+      username: 'Nicholas.Stanton',
+      email: 'Rey.Padberg@rosamond.biz',
+    },
+  ];
+
+  onGridInit(data: DataSet) {
+    const rows = data.getRows();
+    setInterval(() => {
+      const randomIndex = Math.floor(Math.random() * rows.length - 1) + 1;
+      data.multipleSelectRow(rows[randomIndex]);
+    }, 1000);
+  }
+}

--- a/projects/demo/src/app/pages/examples/various/various-examples.component.html
+++ b/projects/demo/src/app/pages/examples/various/various-examples.component.html
@@ -15,3 +15,10 @@
   <a class="source" href="https://github.com/akveo/ng2-smart-table/blob/master/src/app/pages/examples/various/basic-example-multi-select.component.ts" target="_blank">Demo Source</a>
   <basic-example-multi-select></basic-example-multi-select>
 </div>
+
+<h3><a id="rowselection" class="anchor" href="#rowselection" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Row Selection</h3>
+<p>An example on how select a row programmatically</p>
+<div class="with-source">
+  <a class="source" href="https://github.com/akveo/ng2-smart-table/blob/master/src/app/pages/examples/various/basic-example-row-selection.ts" target="_blank">Demo Source</a>
+  <basic-example-row-selection></basic-example-row-selection>
+</div>

--- a/projects/demo/src/app/pages/examples/various/various-examples.component.ts
+++ b/projects/demo/src/app/pages/examples/various/various-examples.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'various-examples',

--- a/projects/demo/src/styles.scss
+++ b/projects/demo/src/styles.scss
@@ -1,0 +1,1 @@
+/* Put here demo core styles */

--- a/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
+++ b/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
@@ -9,7 +9,7 @@ export class DataSet {
   protected columns: Array<Column> = [];
   protected rows: Array<Row> = [];
   protected selectedRow: Row;
-  protected willSelect: string = 'first';
+  protected willSelect: string = null;
 
   constructor(data: Array<any> = [], protected columnSettings: Object) {
     this.createColumns(columnSettings);
@@ -51,8 +51,9 @@ export class DataSet {
 
   selectRow(row: Row): Row {
     const previousIsSelected = row.isSelected;
-    this.deselectAll();
 
+    this.deselectAll();
+    
     row.isSelected = !previousIsSelected;
     this.selectedRow = row;
 
@@ -111,8 +112,6 @@ export class DataSet {
         this.selectLastRow();
       }
       this.willSelect = '';
-    } else {
-      this.selectFirstRow();
     }
 
     return this.selectedRow;

--- a/projects/ng2-smart-table/src/lib/ng2-smart-table.component.ts
+++ b/projects/ng2-smart-table/src/lib/ng2-smart-table.component.ts
@@ -1,11 +1,11 @@
 import { Component, Input, Output, SimpleChange, EventEmitter, OnChanges } from '@angular/core';
 
 import { Grid } from './lib/grid';
-import { DataSource } from './lib/data-source/data-source';
 import { Row } from './lib/data-set/row';
 import { deepExtend } from './lib/helpers';
 import { LocalDataSource } from './lib/data-source/local/local.data-source';
-
+import { DataSet } from './lib/data-set/data-set';
+import { DataSource } from './lib/data-source/data-source';
 @Component({
   selector: 'ng2-smart-table',
   styleUrls: ['./ng2-smart-table.component.scss'],
@@ -26,6 +26,7 @@ export class Ng2SmartTableComponent implements OnChanges {
   @Output() editConfirm = new EventEmitter<any>();
   @Output() createConfirm = new EventEmitter<any>();
   @Output() rowHover: EventEmitter<any> = new EventEmitter<any>();
+  @Output() afterGridInit: EventEmitter<DataSet> = new EventEmitter<DataSet>();
 
   tableClass: string;
   tableId: string;
@@ -34,7 +35,6 @@ export class Ng2SmartTableComponent implements OnChanges {
   isHideSubHeader: boolean;
   isPagerDisplay: boolean;
   rowClassFunction: Function;
-
 
   grid: Grid;
   defaultSettings: Object = {
@@ -155,6 +155,10 @@ export class Ng2SmartTableComponent implements OnChanges {
     this.source = this.prepareSource();
     this.grid = new Grid(this.source, this.prepareSettings());
     this.grid.onSelectRow().subscribe((row) => this.emitSelectRow(row));
+    /** Delay a bit the grid init event trigger to prevent empty rows */
+    setTimeout(() => {
+      this.afterGridInit.emit(this.grid.dataSet);
+    }, 10);
   }
 
   prepareSource(): DataSource {


### PR DESCRIPTION
According with the issue [502](https://github.com/akveo/ng2-smart-table/issues/502) this pull request resolves the first row selection bug with selectionMode != 'multi'.

This pull request also includes a new Output method for the **ng2-smart-table** component:

## afterGridInit
Called after new Grid method completed, will pass the DataSet as param:

### Example

1. Set a callback for the Output:
```html
<ng2-smart-table
        [...]
        (afterGridInit)="onGridInit($event)"
></ng2-smart-table>
```
2. Do what you need after grid init, for example select a certain row:
```typescript
  onGridInit(data: DataSet) {
    if ( !this.selectedData ) {
      return;
    }
    
    data.getRows().map(
      row => {
        if ( row.getData() === this.selectedData ) {
          data.selectRow(row);
        }
      }
    );
  }
```