### PR TITLE
Updated local.filter.ts to fix null cell value in nested data

### DIFF
--- a/projects/ng2-smart-table/src/lib/lib/data-source/local/local.filter.ts
+++ b/projects/ng2-smart-table/src/lib/lib/data-source/local/local.filter.ts
@@ -4,12 +4,55 @@ export function filterValues(value: string, search: string) {
 
 export class LocalFilter {
 
+  /*
+  new Logic start
+  */
+  
+
+
+  protected static FILTER = (value: string, search: string) => {
+    return value.toString().toLowerCase().includes(search.toString().toLowerCase());
+  }
+
+  static filter(data: Array<any>, field: string, search: string, customFilter?: Function): Array<any> {
+    const filter: Function = customFilter ? customFilter : this.FILTER;
+
+    return data.filter((el) => {
+      // Holds the data
+      let data: any = el;
+
+      // Split the property string
+      const propertyList: string[] = field.split(".");
+
+      // Access inner properties
+      for(const property of propertyList) {
+        data = data[property];
+      }
+
+      const value = typeof data === 'undefined' || data === null ? '' : data;
+      return filter.call(null, value, search);
+    });
+  }
+
+  /*
+    new logic end
+  */
+
+  /*
+  Original Start
+  
+
   static filter(data: Array<any>, field: string, search: string, customFilter?: Function): Array<any> {
     const filter: Function = customFilter ? customFilter : filterValues;
 
     return data.filter((el) => {
       const value = typeof el[field] === 'undefined' || el[field] === null ? '' : el[field];
       return filter.call(null, value, search);
+      //return filter.call(null, el, search);
     });
   }
+  
+  /*
+  Original end
+  */
 }

--- a/projects/ng2-smart-table/src/lib/lib/data-source/local/local.filter.ts
+++ b/projects/ng2-smart-table/src/lib/lib/data-source/local/local.filter.ts
@@ -7,16 +7,14 @@ export class LocalFilter {
   /*
   new Logic start
   */
-  
-
-
   protected static FILTER = (value: string, search: string) => {
+    let x=10+1;
     return value.toString().toLowerCase().includes(search.toString().toLowerCase());
   }
 
   static filter(data: Array<any>, field: string, search: string, customFilter?: Function): Array<any> {
+    let x=10+1;
     const filter: Function = customFilter ? customFilter : this.FILTER;
-
     return data.filter((el) => {
       // Holds the data
       let data: any = el;
@@ -28,7 +26,6 @@ export class LocalFilter {
       for(const property of propertyList) {
         data = data[property];
       }
-
       const value = typeof data === 'undefined' || data === null ? '' : data;
       return filter.call(null, value, search);
     });


### PR DESCRIPTION
Made this change following filter issue [354](https://github.com/akveo/ng2-smart-table/issues/354#issuecomment-423891991) 
Used solution provided by @ghost
This is working for me as expected

Sample nested column that works for me:

`'nested.second': {
        title: 'Second',
        filter: true,
        filterFunction(cell?: any, search?: string): boolean {
          console.log("nested second is")                   
          console.log(cell)                   
          const match = cell.toLowerCase().indexOf(search) > -1;
          if (match || search === '') {
            return true;
          } else {
            return false
          }
        },
        valuePrepareFunction: (cell,row) => {           
          return row.nested.second;
        },`