### PR TITLE
Columns resizing

### DIFF
--- a/projects/ng2-smart-table/src/lib/components/thead/rows/thead-titles-row.component.ts
+++ b/projects/ng2-smart-table/src/lib/components/thead/rows/thead-titles-row.component.ts
@@ -17,6 +17,7 @@ import { Column } from "../../../lib/data-set/column";
     <th *ngFor="let column of grid.getColumns()" class="ng2-smart-th {{ column.id }}" [ngClass]="column.class"
       [style.width]="column.width" >
       <ng2-st-column-title [source]="source" [column]="column" (sort)="sort.emit($event)"></ng2-st-column-title>
+      <div *ngIf="isResizable" ng2-resizer class="ng2-resizer-block"></div>
     </th>
     <th ng2-st-actions-title *ngIf="showActionColumnRight" [grid]="grid"></th>
   `,
@@ -33,12 +34,14 @@ export class TheadTitlesRowComponent implements OnChanges {
   isMultiSelectVisible: boolean;
   showActionColumnLeft: boolean;
   showActionColumnRight: boolean;
+  isResizable: boolean;
 
 
   ngOnChanges() {
     this.isMultiSelectVisible = this.grid.isMultiSelectVisible();
     this.showActionColumnLeft = this.grid.showActionColumn('left');
     this.showActionColumnRight = this.grid.showActionColumn('right');
+    this.isResizable = this.grid.getSetting('resizable');
   }
 
 }

--- a/projects/ng2-smart-table/src/lib/components/thead/thead.component.ts
+++ b/projects/ng2-smart-table/src/lib/components/thead/thead.component.ts
@@ -31,7 +31,7 @@ export class Ng2SmartTableTheadComponent implements OnChanges {
   }
 
   @HostListener('mousemove', ['$event'])
-  private mouseMove(event: MouseEvent) {
+  mouseMove(event: MouseEvent) {
     this.tableService.mouseMoveEvent$.next(event);
   }
 }

--- a/projects/ng2-smart-table/src/lib/components/thead/thead.component.ts
+++ b/projects/ng2-smart-table/src/lib/components/thead/thead.component.ts
@@ -1,29 +1,37 @@
-import {Component, Input, Output, EventEmitter, OnChanges} from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, HostListener } from '@angular/core';
 
 import { Grid } from '../../lib/grid';
 import { DataSource } from '../../lib/data-source/data-source';
+import { TableService } from '../../services/table.service';
 
 @Component({
-    selector: '[ng2-st-thead]',
-    templateUrl: './thead.component.html',
+  selector: '[ng2-st-thead]', templateUrl: './thead.component.html',
 })
 export class Ng2SmartTableTheadComponent implements OnChanges {
 
-    @Input() grid: Grid;
-    @Input() source: DataSource;
-    @Input() isAllSelected: boolean;
-    @Input() createConfirm: EventEmitter<any>;
+  @Input() grid: Grid;
+  @Input() source: DataSource;
+  @Input() isAllSelected: boolean;
+  @Input() createConfirm: EventEmitter<any>;
 
-    @Output() sort = new EventEmitter<any>();
-    @Output() selectAllRows = new EventEmitter<any>();
-    @Output() create = new EventEmitter<any>();
-    @Output() filter = new EventEmitter<any>();
+  @Output() sort = new EventEmitter<any>();
+  @Output() selectAllRows = new EventEmitter<any>();
+  @Output() create = new EventEmitter<any>();
+  @Output() filter = new EventEmitter<any>();
 
-    isHideHeader: boolean;
-    isHideSubHeader: boolean;
+  isHideHeader: boolean;
+  isHideSubHeader: boolean;
+
+  constructor(private tableService: TableService) {
+  }
 
   ngOnChanges() {
-      this.isHideHeader = this.grid.getSetting('hideHeader');
-      this.isHideSubHeader = this.grid.getSetting('hideSubHeader');
-    }
+    this.isHideHeader = this.grid.getSetting('hideHeader');
+    this.isHideSubHeader = this.grid.getSetting('hideSubHeader');
+  }
+
+  @HostListener('mousemove', ['$event'])
+  private mouseMove(event: MouseEvent) {
+    this.tableService.mouseMoveEvent$.next(event);
+  }
 }

--- a/projects/ng2-smart-table/src/lib/components/thead/thead.module.ts
+++ b/projects/ng2-smart-table/src/lib/components/thead/thead.module.ts
@@ -15,6 +15,7 @@ import { TitleComponent } from './cells/title/title.component';
 import { TheadFitlersRowComponent } from './rows/thead-filters-row.component';
 import { TheadFormRowComponent } from './rows/thead-form-row.component';
 import { TheadTitlesRowComponent } from './rows/thead-titles-row.component';
+import { DirectivesModule } from '../../directives/directives.module';
 
 const THEAD_COMPONENTS = [
   ActionsComponent,
@@ -26,7 +27,7 @@ const THEAD_COMPONENTS = [
   TheadFitlersRowComponent,
   TheadFormRowComponent,
   TheadTitlesRowComponent,
-  Ng2SmartTableTheadComponent,
+  Ng2SmartTableTheadComponent
 ];
 
 @NgModule({
@@ -35,6 +36,7 @@ const THEAD_COMPONENTS = [
     FormsModule,
     FilterModule,
     CellModule,
+    DirectivesModule
   ],
   declarations: [
     ...THEAD_COMPONENTS,

--- a/projects/ng2-smart-table/src/lib/directives/directives.module.ts
+++ b/projects/ng2-smart-table/src/lib/directives/directives.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { Ng2ResizerDirective } from './resizer.directive';
+
+const DIRECTIVES = [
+  Ng2ResizerDirective
+];
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [
+    ...DIRECTIVES,
+  ],
+  exports: [
+    ...DIRECTIVES,
+  ],
+})
+export class DirectivesModule { }

--- a/projects/ng2-smart-table/src/lib/directives/resizer.directive.ts
+++ b/projects/ng2-smart-table/src/lib/directives/resizer.directive.ts
@@ -1,0 +1,56 @@
+import { Directive, ElementRef, HostListener, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { Subject } from 'rxjs';
+import { filter, takeUntil } from 'rxjs/operators';
+
+import { TableService } from '../services/table.service';
+
+@Directive({
+  selector: '[ng2-resizer]'
+})
+export class Ng2ResizerDirective implements OnInit, OnDestroy {
+  isClicked: boolean;
+
+  parentElement: any;
+  siblingElement: any;
+
+  pointerOffset: number;
+  parentOffset: number;
+  siblingOffset: number;
+
+  destroyed$ = new Subject<any>();
+
+  constructor(private elementRef: ElementRef, private renderer: Renderer2, private tableService: TableService) {
+  }
+
+  ngOnInit() {
+    this.tableService.mouseMoveEvent$
+      .pipe(
+        takeUntil(this.destroyed$),
+        filter(() => this.isClicked)
+      )
+      .subscribe((event: MouseEvent) => {
+        const offset = this.pointerOffset - event.pageX;
+        const width = this.parentOffset - offset;
+        this.renderer.setStyle(this.parentElement, 'width', width + 'px');
+        this.renderer.setStyle(this.siblingElement, 'width', this.siblingOffset + offset + 'px');
+      });
+  }
+
+  @HostListener('mousedown', ['$event']) onMouseEnter(event: MouseEvent) {
+    this.isClicked = true;
+    this.parentElement = this.renderer.parentNode(this.elementRef.nativeElement);
+    this.siblingElement = this.renderer.nextSibling(this.parentElement);
+    this.pointerOffset = event.pageX;
+
+    this.parentOffset = this.parentElement.offsetWidth;
+    this.siblingOffset = this.siblingElement.offsetWidth;
+  }
+
+  @HostListener('document:mouseup') onMouseDown() {
+    this.isClicked = false;
+  }
+
+  ngOnDestroy() {
+    this.destroyed$.next();
+  }
+}

--- a/projects/ng2-smart-table/src/lib/ng2-smart-table.component.scss
+++ b/projects/ng2-smart-table/src/lib/ng2-smart-table.component.scss
@@ -30,6 +30,16 @@
       tr {
         th {
           font-weight: bold;
+          position: relative;
+
+          .ng2-resizer-block {
+            width: 8px;
+            height: 100%;
+            position: absolute;
+            right: 0;
+            top: 0;
+            cursor: col-resize;
+          }
         }
         section {
           font-size: .75em;

--- a/projects/ng2-smart-table/src/lib/ng2-smart-table.component.ts
+++ b/projects/ng2-smart-table/src/lib/ng2-smart-table.component.ts
@@ -42,6 +42,7 @@ export class Ng2SmartTableComponent implements OnChanges {
     selectMode: 'single', // single|multi
     hideHeader: false,
     hideSubHeader: false,
+    resizable: false,
     actions: {
       columnTitle: 'Actions',
       add: true,

--- a/projects/ng2-smart-table/src/lib/services/table.service.ts
+++ b/projects/ng2-smart-table/src/lib/services/table.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({providedIn: 'root'})
+export class TableService {
+  mouseMoveEvent$ = new Subject<Event>();
+}


### PR DESCRIPTION
Added column resizing.

- To enable resizing - pass **resizable** property.
- To turn off words wrapping in cells - end user should set such css properties for the div inside **table-cell-view-mode** (or similar) component. It was not included in the PR due not to break existing UI:
`    height: 20px; - possible height`
`    overflow: hidden;`
`    word-break: break-all;`