### PR TITLE
feat: add selectedRowIndex to settings and selectRow method

### DIFF
--- a/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
+++ b/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
@@ -49,7 +49,7 @@ export class DataSet {
     });
   }
 
-  selectRow(row: Row): Row {
+  selectRow(row: Row): Row | undefined {
     const previousIsSelected = row.isSelected;
     this.deselectAll();
 
@@ -77,33 +77,34 @@ export class DataSet {
     }
   }
 
-  selectFirstRow(): Row {
+  selectFirstRow(): Row | undefined {
     if (this.rows.length > 0) {
       this.selectRow(this.rows[0]);
       return this.selectedRow;
     }
   }
 
-  selectLastRow(): Row {
+  selectLastRow(): Row | undefined {
     if (this.rows.length > 0) {
       this.selectRow(this.rows[this.rows.length - 1]);
       return this.selectedRow;
     }
   }
 
-  selectRowByIndex(index: number): Row {
+  selectRowByIndex(index: number): Row | undefined {
     const rowsLength: number = this.rows.length;
-    if (rowsLength > 0) {
-      if (!index) {
-        this.selectFirstRow();
-        return this.selectedRow;
-      }
-      if (index >= 0 && index < rowsLength) {
-        this.selectRow(this.rows[index]);
-        return this.selectedRow;
-      }
-      this.deselectAll();
+    if (rowsLength === 0) {
+      return;
     }
+    if (!index) {
+      this.selectFirstRow();
+      return this.selectedRow;
+    }
+    if (index >= 0 && index < rowsLength) {
+      this.selectRow(this.rows[index]);
+      return this.selectedRow;
+    }
+    this.deselectAll();
   }
 
   willSelectFirstRow() {
@@ -114,7 +115,7 @@ export class DataSet {
     this.willSelect = 'last';
   }
 
-  select(selectedRowIndex?: number): Row {
+  select(selectedRowIndex?: number): Row | undefined {
     if (this.getRows().length === 0) {
       return;
     }

--- a/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
+++ b/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
@@ -9,7 +9,7 @@ export class DataSet {
   protected columns: Array<Column> = [];
   protected rows: Array<Row> = [];
   protected selectedRow: Row;
-  protected willSelect: string = 'first';
+  protected willSelect: string;
 
   constructor(data: Array<any> = [], protected columnSettings: Object) {
     this.createColumns(columnSettings);
@@ -91,6 +91,21 @@ export class DataSet {
     }
   }
 
+  selectRowByIndex(index: number): Row {
+    const rowsLength: number = this.rows.length;
+    if (rowsLength > 0) {
+      if (!index) {
+        this.selectFirstRow();
+        return this.selectedRow;
+      }
+      if (index >= 0 && index < rowsLength) {
+        this.selectRow(this.rows[index]);
+        return this.selectedRow;
+      }
+      this.deselectAll();
+    }
+  }
+
   willSelectFirstRow() {
     this.willSelect = 'first';
   }
@@ -99,7 +114,7 @@ export class DataSet {
     this.willSelect = 'last';
   }
 
-  select(): Row {
+  select(selectedRowIndex?: number): Row {
     if (this.getRows().length === 0) {
       return;
     }
@@ -112,7 +127,7 @@ export class DataSet {
       }
       this.willSelect = '';
     } else {
-      this.selectFirstRow();
+      this.selectRowByIndex(selectedRowIndex);
     }
 
     return this.selectedRow;

--- a/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
+++ b/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
@@ -100,7 +100,7 @@ export class DataSet {
       this.selectFirstRow();
       return this.selectedRow;
     }
-    if (index >= 0 && index < rowsLength) {
+    if (index > 0 && index < rowsLength) {
       this.selectRow(this.rows[index]);
       return this.selectedRow;
     }

--- a/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
+++ b/projects/ng2-smart-table/src/lib/lib/data-set/data-set.ts
@@ -47,6 +47,8 @@ export class DataSet {
     this.rows.forEach((row) => {
       row.isSelected = false;
     });
+    // we need to clear selectedRow field because no one row selected
+    this.selectedRow = undefined;
   }
 
   selectRow(row: Row): Row | undefined {
@@ -104,6 +106,7 @@ export class DataSet {
       this.selectRow(this.rows[index]);
       return this.selectedRow;
     }
+    // we need to deselect all rows if we got an incorrect index
     this.deselectAll();
   }
 

--- a/projects/ng2-smart-table/src/lib/lib/grid.ts
+++ b/projects/ng2-smart-table/src/lib/lib/grid.ts
@@ -298,6 +298,18 @@ export class Grid {
   private getRowIndexToSelect(): number {
     const { switchPageToSelectedRowPage, selectedRowIndex, perPage } = this.getSelectionInfo();
     const dataAmount: number = this.source.count();
+    /**
+     * source - contains all table data
+     * dataSet - contains data for current page
+     * selectedRowIndex - contains index for data in all data
+     *
+     * because of that, we need to count index for a specific row in page
+     * if
+     * `switchPageToSelectedRowPage` - we need to change page automatically
+     * `selectedRowIndex < dataAmount && selectedRowIndex >= 0` - index points to existing data
+     * (if index points to non-existing data and we calculate index for current page - we will get wrong selected row.
+     *  if we return index witch not points to existing data - no line will be highlighted)
+     */
     return (
       switchPageToSelectedRowPage &&
       selectedRowIndex < dataAmount &&

--- a/projects/ng2-smart-table/src/lib/lib/grid.ts
+++ b/projects/ng2-smart-table/src/lib/lib/grid.ts
@@ -2,7 +2,7 @@ import { Subject, Subscription } from 'rxjs';
 import { Observable } from 'rxjs';
 import { EventEmitter } from '@angular/core';
 
-import { Deferred, getDeepFromObject, getPageToSelect } from './helpers';
+import { Deferred, getDeepFromObject, getPageForRowIndex } from './helpers';
 import { Column } from './data-set/column';
 import { Row } from './data-set/row';
 import { DataSet } from './data-set/data-set';
@@ -17,6 +17,7 @@ export class Grid {
   dataSet: DataSet;
 
   onSelectRowSource = new Subject<any>();
+  onDeselectRowSource = new Subject<any>();
 
   private sourceOnChangedSubscription: Subscription;
   private sourceOnUpdatedSubscription: Subscription;
@@ -102,6 +103,10 @@ export class Grid {
 
   onSelectRow(): Observable<any> {
     return this.onSelectRowSource.asObservable();
+  }
+
+  onDeselectRow(): Observable<any> {
+    return this.onDeselectRowSource.asObservable();
   }
 
   edit(row: Row) {
@@ -192,6 +197,8 @@ export class Grid {
 
         if (row) {
           this.onSelectRowSource.next(row);
+        } else {
+          this.onDeselectRowSource.next(null);
         }
       }
     }
@@ -304,7 +311,7 @@ export class Grid {
     const { switchPageToSelectedRowPage, selectedRowIndex, perPage, page } = this.getSelectionInfo();
     let pageToSelect: number = Math.max(1, page);
     if (switchPageToSelectedRowPage && selectedRowIndex >= 0) {
-      pageToSelect = getPageToSelect(selectedRowIndex, perPage);
+      pageToSelect = getPageForRowIndex(selectedRowIndex, perPage);
     }
     const maxPageAmount: number = Math.ceil(source.count() / perPage);
     return maxPageAmount ? Math.min(pageToSelect, maxPageAmount) : pageToSelect;

--- a/projects/ng2-smart-table/src/lib/lib/helpers.ts
+++ b/projects/ng2-smart-table/src/lib/lib/helpers.ts
@@ -97,7 +97,7 @@ export function getDeepFromObject(object = {}, name: string, defaultValue?: any)
   return typeof level === 'undefined' ? defaultValue : level;
 }
 
-export function getPageToSelect(index: number, perPage: number): number {
+export function getPageForRowIndex(index: number, perPage: number): number {
   // we need to add 1 to convert 0-based index to 1-based page number.
   return Math.floor(index / perPage) + 1;
 }

--- a/projects/ng2-smart-table/src/lib/lib/helpers.ts
+++ b/projects/ng2-smart-table/src/lib/lib/helpers.ts
@@ -96,3 +96,8 @@ export function getDeepFromObject(object = {}, name: string, defaultValue?: any)
 
   return typeof level === 'undefined' ? defaultValue : level;
 }
+
+export function getPageToSelect(index: number, perPage: number): number {
+  // we need to add 1 to convert 0-based index to 1-based page number.
+  return Math.floor(index / perPage) + 1;
+}

--- a/projects/ng2-smart-table/src/lib/ng2-smart-table.component.ts
+++ b/projects/ng2-smart-table/src/lib/ng2-smart-table.component.ts
@@ -42,7 +42,7 @@ export class Ng2SmartTableComponent implements OnChanges, OnDestroy {
   defaultSettings: Object = {
     mode: 'inline', // inline|external|click-to-edit
     selectMode: 'single', // single|multi
-    selectedRowIndex: 0,
+    selectedRowIndex: 0, // points to an element in all data
     switchPageToSelectedRowPage: false,
     hideHeader: false,
     hideSubHeader: false,


### PR DESCRIPTION
add selectRowIndex and switchPageToSelectedRowPage fields to settings for initial selecting row in current page

selectRowIndex - used to indicate the index of the data whose corresponding row is to be selected
switchPageToSelectedRowPage - used to indicate whether to switch pages automatically to highlight the desired data

add selectRow(index, switchPageToSelectedRowPage?) public method to ng2-smart-table, which allows you to highlight the required row

add rowDeselect Output for ng2-smart-table

Closes #204
Closes #708