### PR TITLE
refactor: use original ng2-completer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@akveo/ng2-completer": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@akveo/ng2-completer/-/ng2-completer-9.0.1.tgz",
-      "integrity": "sha512-iACL0heOUmGV1GBKD3srwBJMFLZykld1MiTDvmbgEEXMhavp0UA45GdNsv7BBKI9XauuFKpOqHLlC+fT6DLGAQ=="
-    },
     "@angular-devkit/architect": {
       "version": "0.900.4",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.900.4.tgz",
@@ -11183,6 +11178,11 @@
           }
         }
       }
+    },
+    "ng2-completer": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ng2-completer/-/ng2-completer-9.0.1.tgz",
+      "integrity": "sha512-zEKehHdCK8E/k4Y0HepprGdYBHr2AOsaq4QpeqoCyUElOOC5M3qi3ZEHV1VF54I7heBQktswwXe5UyWduJ0Xeg=="
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/router": "~9.0.4",
     "highlight.js": "^9.15.8",
     "lodash": "^4.17.10",
-    "@akveo/ng2-completer": "9.0.1",
+    "ng2-completer": "^9.0.1",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2"

--- a/projects/ng2-smart-table/package.json
+++ b/projects/ng2-smart-table/package.json
@@ -8,7 +8,7 @@
     "lodash": "^4.17.10"
   },
   "peerDependencies": {
-    "@akveo/ng2-completer": "9.0.1",
+    "ng2-completer": "^9.0.1",
     "@angular/common": "^9.0.0",
     "@angular/core": "^9.0.0",
     "@angular/forms": "^9.0.0",

--- a/projects/ng2-smart-table/src/lib/components/cell/cell-editors/completer-editor.component.ts
+++ b/projects/ng2-smart-table/src/lib/components/cell/cell-editors/completer-editor.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { CompleterService } from '@akveo/ng2-completer';
+import { CompleterService } from 'ng2-completer';
 
 import { DefaultEditor } from './default-editor';
 

--- a/projects/ng2-smart-table/src/lib/components/cell/cell.module.ts
+++ b/projects/ng2-smart-table/src/lib/components/cell/cell.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Ng2CompleterModule } from '@akveo/ng2-completer';
+import { Ng2CompleterModule } from 'ng2-completer';
 
 import { CellComponent } from './cell.component';
 import { CustomEditComponent } from './cell-edit-mode/custom-edit.component';

--- a/projects/ng2-smart-table/src/lib/components/filter/filter-types/completer-filter.component.ts
+++ b/projects/ng2-smart-table/src/lib/components/filter/filter-types/completer-filter.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Subject } from 'rxjs';
-import { CompleterService } from '@akveo/ng2-completer';
+import { CompleterService } from 'ng2-completer';
 
 import { DefaultFilter } from './default-filter';
 import { distinctUntilChanged, debounceTime, map } from 'rxjs/operators';

--- a/projects/ng2-smart-table/src/lib/components/filter/filter.module.ts
+++ b/projects/ng2-smart-table/src/lib/components/filter/filter.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { Ng2CompleterModule } from '@akveo/ng2-completer';
+import { Ng2CompleterModule } from 'ng2-completer';
 
 import { FilterComponent } from './filter.component';
 import { DefaultFilterComponent } from "./default-filter.component";


### PR DESCRIPTION
BREAKING CHANGE:
`@akveo/ng2-completer` dependency replaced by ng2-completer as original package was fixed. Note on why we have to fork package could be found [here](https://github.com/akveo/ng2-smart-table/pull/1140#issue-392285957). Please, uninstall `@akveo/ng2-completer` and install `ng2-completer`:
```
npm uninstall --save @akveo/ng2-completer
npm install ng2-completer
```